### PR TITLE
Changed F/A-18C bombs from Green to Grey Versions

### DIFF
--- a/FA-18C_hornet/VFA-143 - 200 - Void - CAG/description.lua
+++ b/FA-18C_hornet/VFA-143 - 200 - Void - CAG/description.lua
@@ -11,7 +11,30 @@ livery = {
 	{"pilot_F18_patch", 1 ,"Pilot_F18_Patch_NORM_PukinDogs",false};
 	{"pilot_F18_patch", ROUGHNESS_METALLIC ,"Pilot_F18_Patch_PukinDogs_RoughMet",false};
 	{"pilot_F18_helmet", 0, "pilot_F18_helmet_VMFAAW224_bengal", false};
-	
+		--Grey Naval bombs
+	{"GBU_12",	DIFFUSE			,	"gbu_12t_gray_diff", true};
+	{"GBU_12",	NORMAL_MAP			,	"gbu_12_nm", true};
+	{"GBU_12",	ROUGHNESS_METALLIC			,	"gbu_12_diff_roughmet", true};
+	{"MK_82", DIFFUSE, "mk_82t_grey_diff", true};
+	{"MK_82", NORMAL_MAP, "mk_82_nm", true};
+	{"MK_82", ROUGHNESS_METALLIC, "mk_82_diff_roughmet", true};
+	{"mk_83", DIFFUSE, "mk_83tgrey_diff", true};
+	{"mk_83", NORMAL_MAP, "mk_83_nm", true};
+	{"mk_83", ROUGHNESS_METALLIC, "mk_83_diff_roughmet", true};
+	{"GBU_38", DIFFUSE, "gbu_38t_diff", true};
+	{"GBU_38", NORMAL_MAP, "gbu_38_nm", true};
+	{"GBU_38", ROUGHNESS_METALLIC, "gbu_38_diff_roughmet", true};
+	{"GBU_31", DIFFUSE, "gbu_31t_gray_diff", true};
+	{"GBU_31", NORMAL_MAP, "gbu_31_nm", true};
+	{"GBU_31", ROUGHNESS_METALLIC, "gbu_31_diff_roughmet", true};
+	{"mk_84", NORMAL_MAP, "mk_84_nm", true};
+	{"mk_84", ROUGHNESS_METALLIC, "mk_84_diff_roughmet", true};
+	{"GBU_10", DIFFUSE, "gbu_10_diff", true};
+	{"GBU_10", NORMAL_MAP, "gbu_10_nm", true};
+	{"GBU_10", ROUGHNESS_METALLIC, "gbu_10_diff_roughmet", true};
+	{"GBU_16", DIFFUSE, "gbu_16t_gray_diff", true};
+	{"GBU_16", NORMAL_MAP, "gbu_16t_nm", true};
+	{"GBU_16", ROUGHNESS_METALLIC, "gbu_16t_gray_diff_roughmet", true};
 	--Fuel Tanks
 	{"FPU_8A", 0 ,"FPU_8A_PukinDogs_CO",false};
 	{"FPU_8A", ROUGHNESS_METALLIC ,"FPU_8A_Diff_RoughMet",true};

--- a/FA-18C_hornet/VFA-143 - 200 - Void - CAG/description.lua.bak
+++ b/FA-18C_hornet/VFA-143 - 200 - Void - CAG/description.lua.bak
@@ -10,7 +10,7 @@ livery = {
 	{"pilot_F18_patch", 0 ,"Pilot_F18_Patch_PukinDogs",false};
 	{"pilot_F18_patch", 1 ,"Pilot_F18_Patch_NORM_PukinDogs",false};
 	{"pilot_F18_patch", ROUGHNESS_METALLIC ,"Pilot_F18_Patch_PukinDogs_RoughMet",false};
-	{"pilot_F18_helmet", 0, "../VFA-143Textures/Helmets/pilot_F18_helmet_APOLLO", false};
+	{"pilot_F18_helmet", 0, "pilot_F18_helmet_VMFAAW224_bengal", false};
 	
 	--Fuel Tanks
 	{"FPU_8A", 0 ,"FPU_8A_PukinDogs_CO",false};
@@ -23,25 +23,25 @@ livery = {
 	
 	--*NEW 2.8.4 Bort Numbers*
 	--USN_MODEX_NOSE
-	{"f18c1_number_nose_left"			, DIFFUSE				, "F18C_1_DIFF_VMFA_224_Bengals", false};
+	{"f18c1_number_nose_left"			, DIFFUSE				, "F18C_1_DIFF_VFA143_PukinDogs_Line", false};
 	{"f18c1_number_nose_left"			, SPECULAR				, "F18C_1_DIF_RoughMet", false};
 	{"f18c1_number_nose_left"			, DECAL					, "empty", true};
-	{"f18c1_number_nose_right"			, DIFFUSE				, "F18C_1_DIFF_VMFA_224_Bengals", false};
+	{"f18c1_number_nose_right"			, DIFFUSE				, "F18C_1_DIFF_VFA143_PukinDogs_Line", false};
 	{"f18c1_number_nose_right"			, SPECULAR				, "F18C_1_DIF_RoughMet", false};
 	{"f18c1_number_nose_right"			, DECAL					, "empty", true};
 	--RAAF /KAF/SWITZ_MODEX_FUSELAGE_FRONT_MID_BACK_GEAR_DOORS_SMALL
-	{"f18c1_number_F"					, DIFFUSE				, "F18C_1_DIFF_VMFA_224_Bengals", false};
+	{"f18c1_number_F"					, DIFFUSE				, "F18C_1_DIFF_VFA143_PukinDogs_Line", false};
 	{"f18c1_number_F"					, SPECULAR				, "F18C_1_DIF_RoughMet", false};
 	{"f18c1_number_F"					, DECAL					, "empty", true};
 	--KAF_MODEX_VERTICAL_STABILIZERS_AND_FLAPS_MODEX
-	{"f18c2_number_X"					, DIFFUSE				, "F18C_2_DIFF_VMFA_224_Bengals", false};
+	{"f18c2_number_X"					, DIFFUSE				, "F18C_2_DIFF_VFA143_PukinDogs_Line", false};
 	{"f18c2_number_X"					, SPECULAR				, "F18C_2_DIF_RoughMet", false};
 	{"f18c2_number_X"					, DECAL					, "empty", true};
 	--USN_MODEX_VERTICAL_STABILIZERS
-	{"f18c2_kil_left"					, DIFFUSE				, "F18C_2_DIFF_VMFA_224_Bengals", false};
+	{"f18c2_kil_left"					, DIFFUSE				, "F18C_2_DIFF_VFA143_PukinDogs_Line", false};
 	{"f18c2_kil_left"					, SPECULAR				, "F18C_2_DIF_RoughMet", false};
 	{"f18c2_kil_left"					, DECAL					, "empty", true};
-	{"f18c2_kil_right"					, DIFFUSE				, "F18C_2_DIFF_VMFA_224_Bengals", false};
+	{"f18c2_kil_right"					, DIFFUSE				, "F18C_2_DIFF_VFA143_PukinDogs_Line", false};
 	{"f18c2_kil_right"					, SPECULAR				, "F18C_2_DIF_RoughMet", false};
 	{"f18c2_kil_right"					, DECAL					, "empty", true};	
 	

--- a/FA-18C_hornet/VFA-143 - 201 - Goon - CO/description.lua
+++ b/FA-18C_hornet/VFA-143 - 201 - Goon - CO/description.lua
@@ -11,7 +11,30 @@ livery = {
 	{"pilot_F18_patch", 1 ,"Pilot_F18_Patch_NORM_PukinDogs",false};
 	{"pilot_F18_patch", ROUGHNESS_METALLIC ,"Pilot_F18_Patch_PukinDogs_RoughMet",false};
 	{"pilot_F18_helmet", 0, "../VFA-143Textures/PILOT_F18_HELMET_VFA_DEFAULT", false};
-	
+	--Grey Naval bombs
+	{"GBU_12",	DIFFUSE			,	"gbu_12t_gray_diff", true};
+	{"GBU_12",	NORMAL_MAP			,	"gbu_12_nm", true};
+	{"GBU_12",	ROUGHNESS_METALLIC			,	"gbu_12_diff_roughmet", true};
+	{"MK_82", DIFFUSE, "mk_82t_grey_diff", true};
+	{"MK_82", NORMAL_MAP, "mk_82_nm", true};
+	{"MK_82", ROUGHNESS_METALLIC, "mk_82_diff_roughmet", true};
+	{"mk_83", DIFFUSE, "mk_83tgrey_diff", true};
+	{"mk_83", NORMAL_MAP, "mk_83_nm", true};
+	{"mk_83", ROUGHNESS_METALLIC, "mk_83_diff_roughmet", true};
+	{"GBU_38", DIFFUSE, "gbu_38t_diff", true};
+	{"GBU_38", NORMAL_MAP, "gbu_38_nm", true};
+	{"GBU_38", ROUGHNESS_METALLIC, "gbu_38_diff_roughmet", true};
+	{"GBU_31", DIFFUSE, "gbu_31t_gray_diff", true};
+	{"GBU_31", NORMAL_MAP, "gbu_31_nm", true};
+	{"GBU_31", ROUGHNESS_METALLIC, "gbu_31_diff_roughmet", true};
+	{"mk_84", NORMAL_MAP, "mk_84_nm", true};
+	{"mk_84", ROUGHNESS_METALLIC, "mk_84_diff_roughmet", true};
+	{"GBU_10", DIFFUSE, "gbu_10_diff", true};
+	{"GBU_10", NORMAL_MAP, "gbu_10_nm", true};
+	{"GBU_10", ROUGHNESS_METALLIC, "gbu_10_diff_roughmet", true};
+	{"GBU_16", DIFFUSE, "gbu_16t_gray_diff", true};
+	{"GBU_16", NORMAL_MAP, "gbu_16t_nm", true};
+	{"GBU_16", ROUGHNESS_METALLIC, "gbu_16t_gray_diff_roughmet", true};	
 	--Fuel Tanks
 	{"FPU_8A", 0 ,"FPU_8A_PukinDogs_CO",false};
 	{"FPU_8A", ROUGHNESS_METALLIC ,"FPU_8A_Diff_RoughMet",true};

--- a/FA-18C_hornet/VFA-143 - 201 - Goon - CO/description.lua.bak
+++ b/FA-18C_hornet/VFA-143 - 201 - Goon - CO/description.lua.bak
@@ -21,187 +21,46 @@ livery = {
     --{"f18c_stay", 1, "f18c_1_diff_stay_nm", true};
     --{"f18c_stay", 2, "f18c_1_diff_stay_dif_roughmet", true};
 	
-	--Nose Aircraft Numbers (USN)
-	--Left
-	{"F18C_BORT_NUMBER_NOSE_L_100", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_CO",false};
-	{"F18C_BORT_NUMBER_NOSE_L_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_L_10", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_CO",false};
-	{"F18C_BORT_NUMBER_NOSE_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_L_01", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_CO",false};
-	{"F18C_BORT_NUMBER_NOSE_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_NOSE_R_100", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_CO",false};
-	{"F18C_BORT_NUMBER_NOSE_R_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_R_10", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_CO",false};
-	{"F18C_BORT_NUMBER_NOSE_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_R_01", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_CO",false};
-	{"F18C_BORT_NUMBER_NOSE_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_R_01", DECAL ,"empty",true};	
-		
-	--Flap Aircraft Numbers (USN)
-	--Left
-	{"F18C_BORT_NUMBER_ZAK_L_100", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_CO",false};
-	{"F18C_BORT_NUMBER_ZAK_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_ZAK_L_10", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_CO",false};
-	{"F18C_BORT_NUMBER_ZAK_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_ZAK_L_01", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_CO",false};
-	{"F18C_BORT_NUMBER_ZAK_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_ZAK_R_100", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_CO",false};
-	{"F18C_BORT_NUMBER_ZAK_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_ZAK_R_10", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_CO",false};
-	{"F18C_BORT_NUMBER_ZAK_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_ZAK_R_01", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_CO",false};
-	{"F18C_BORT_NUMBER_ZAK_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_R_01", DECAL ,"empty",true};
+	--*NEW 2.8.4 Bort Numbers*
+	--USN_MODEX_NOSE
+	{"f18c1_number_nose_left"			, DIFFUSE				, "F18C_1_DIFF_VMFA_224_Bengals", false};
+	{"f18c1_number_nose_left"			, SPECULAR				, "F18C_1_DIF_RoughMet", false};
+	{"f18c1_number_nose_left"			, DECAL					, "empty", true};
+	{"f18c1_number_nose_right"			, DIFFUSE				, "F18C_1_DIFF_VMFA_224_Bengals", false};
+	{"f18c1_number_nose_right"			, SPECULAR				, "F18C_1_DIF_RoughMet", false};
+	{"f18c1_number_nose_right"			, DECAL					, "empty", true};
+	--RAAF /KAF/SWITZ_MODEX_FUSELAGE_FRONT_MID_BACK_GEAR_DOORS_SMALL
+	{"f18c1_number_F"					, DIFFUSE				, "F18C_1_DIFF_VMFA_224_Bengals", false};
+	{"f18c1_number_F"					, SPECULAR				, "F18C_1_DIF_RoughMet", false};
+	{"f18c1_number_F"					, DECAL					, "empty", true};
+	--KAF_MODEX_VERTICAL_STABILIZERS_AND_FLAPS_MODEX
+	{"f18c2_number_X"					, DIFFUSE				, "F18C_2_DIFF_VMFA_224_Bengals", false};
+	{"f18c2_number_X"					, SPECULAR				, "F18C_2_DIF_RoughMet", false};
+	{"f18c2_number_X"					, DECAL					, "empty", true};
+	--USN_MODEX_VERTICAL_STABILIZERS
+	{"f18c2_kil_left"					, DIFFUSE				, "F18C_2_DIFF_VMFA_224_Bengals", false};
+	{"f18c2_kil_left"					, SPECULAR				, "F18C_2_DIF_RoughMet", false};
+	{"f18c2_kil_left"					, DECAL					, "empty", true};
+	{"f18c2_kil_right"					, DIFFUSE				, "F18C_2_DIFF_VMFA_224_Bengals", false};
+	{"f18c2_kil_right"					, SPECULAR				, "F18C_2_DIF_RoughMet", false};
+	{"f18c2_kil_right"					, DECAL					, "empty", true};	
 	
-	--Vertical Stab Aircraft Numbers (USN)
-	--Left
-	{"F18C_BORT_NUMBER_KIL_L_100", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_CO",false};
-	{"F18C_BORT_NUMBER_KIL_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_L_10", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_CO",false};
-	{"F18C_BORT_NUMBER_KIL_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_L_01", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_CO",false};
-	{"F18C_BORT_NUMBER_KIL_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_L_01", DECAL ,"empty",true};	
-	--Right
-	{"F18C_BORT_NUMBER_KIL_R_100", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_CO",false};
-	{"F18C_BORT_NUMBER_KIL_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_R_10", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_CO",false};
-	{"F18C_BORT_NUMBER_KIL_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_R_01", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_CO",false};
-	{"F18C_BORT_NUMBER_KIL_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_R_01", DECAL ,"empty",true};		
-
-	--Nose Aircraft Numbers (KUWAIT)
-	--Left
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_100", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_CO",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_10", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_CO",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_01", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_CO",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_100", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_CO",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_10", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_CO",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_01", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_CO",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_01", DECAL ,"empty",true};		
 	
+	--(0.0 = ON, 1.0 OFF)
 
-	--Vertical Stab Numbers (KUWAIT)
-	--Right
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_100", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_CO",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_10", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_CO",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_01", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_CO",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_100", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_CO",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_10", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_CO",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_01", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_CO",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_01", DECAL ,"empty",true};		
-
-	--Nose Aircraft Numbers (FINLAND)
-	--Left
-	{"F18C_BORT_NUMBER_NOSE_fin_L_10", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_CO",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_fin_L_01", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_CO",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_NOSE_fin_R_10", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_CO",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_fin_R_01", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_CO",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_01", DECAL ,"empty",true};			
-
-	--Vertical Tail Numbers (SWITZERLAND)
-	--Right
-	{"F18C_BORT_NUMBER_KIL_Switz_R_100", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_CO",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_10", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_CO",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Switz_R_01", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_CO",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_KIL_Switz_L_100", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_CO",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_10", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_CO",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Switz_L_01", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_CO",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_01", DECAL ,"empty",true};
-
-	--Gear Door Numbers (RAAF)
-	--Right
-	{"F18C_BORT_NUMBER_STV_aus_R_10", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_CO",false};
-	{"F18C_BORT_NUMBER_STV_aus_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_STV_aus_R_01", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_CO",false};
-	{"F18C_BORT_NUMBER_STV_aus_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_STV_aus_L_10", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_CO",false};
-	{"F18C_BORT_NUMBER_STV_aus_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_STV_aus_L_01", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_CO",false};
-	{"F18C_BORT_NUMBER_STV_aus_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_L_01", DECAL ,"empty",true};		
-		
-	--Aft Fuselage Numbers (RAAF)
-	--Right
-	{"F18C_BORT_NUMBER_MTW_aus_R_10", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_CO",false};
-	{"F18C_BORT_NUMBER_MTW_aus_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_MTW_aus_R_01", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_CO",false};
-	{"F18C_BORT_NUMBER_MTW_aus_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_MTW_aus_L_10", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_CO",false};
-	{"F18C_BORT_NUMBER_MTW_aus_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_MTW_aus_L_01", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_CO",false};
-	{"F18C_BORT_NUMBER_MTW_aus_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_L_01", DECAL ,"empty",true};	
+	
 }
+
+custom_args = {
+	[0027] = 1.0, -- USN_MODEX_VERTICAL_STABILIZERS
+	[1000] = 1.0, -- USN_MODEX_FLAPS
+	[1001] = 1.0, -- USN_MODEX_NOSE
+	[1002] = 1.0, -- KUWAIT_MODEX_NOSE_AND_VERTICAL_STABILIZERS
+	[1003] = 1.0, -- AUSTRAILIA_MODEX_REAR_FUSELAGE_AND_GEAR_DOORS
+	[1004] = 1.0, -- FINLAND_MODEX_FORWARD_FUSELAGE
+	[1005] = 1.0, -- SWITZERLAND_MODEX_VERTICAL_STABILIZERS
+}
+
 name = "VFA-143 Pukin' Dogs - 201 - Goon - CO"
 countries = {"USA", "RUS", "FRA", "UKR", "SPN", "NETH", "TUR", "BEL", "GER", "NOR", "CAN", "DEN", "UK", "GRG", "ISR", "ABH", "RSO"}
 --By SkateZilla Graphics Studios 2018 (07.10.2018)

--- a/FA-18C_hornet/VFA-143 - 204 - Whiskeys -JTF CMDR/description.lua
+++ b/FA-18C_hornet/VFA-143 - 204 - Whiskeys -JTF CMDR/description.lua
@@ -11,7 +11,30 @@ livery = {
 	{"pilot_F18_patch", 1 ,"../VFA-143Textures/Pilot_F18_Patch_NORM_PukinDogs",false};
 	{"pilot_F18_patch", ROUGHNESS_METALLIC ,"../VFA-143Textures/Pilot_F18_Patch_PukinDogs_RoughMet",false};
 	{"pilot_F18_helmet", 0, "PILOT_F18_HELMET_Whiskeys", false};
-	
+		--Grey Naval bombs
+	{"GBU_12",	DIFFUSE			,	"gbu_12t_gray_diff", true};
+	{"GBU_12",	NORMAL_MAP			,	"gbu_12_nm", true};
+	{"GBU_12",	ROUGHNESS_METALLIC			,	"gbu_12_diff_roughmet", true};
+	{"MK_82", DIFFUSE, "mk_82t_grey_diff", true};
+	{"MK_82", NORMAL_MAP, "mk_82_nm", true};
+	{"MK_82", ROUGHNESS_METALLIC, "mk_82_diff_roughmet", true};
+	{"mk_83", DIFFUSE, "mk_83tgrey_diff", true};
+	{"mk_83", NORMAL_MAP, "mk_83_nm", true};
+	{"mk_83", ROUGHNESS_METALLIC, "mk_83_diff_roughmet", true};
+	{"GBU_38", DIFFUSE, "gbu_38t_diff", true};
+	{"GBU_38", NORMAL_MAP, "gbu_38_nm", true};
+	{"GBU_38", ROUGHNESS_METALLIC, "gbu_38_diff_roughmet", true};
+	{"GBU_31", DIFFUSE, "gbu_31t_gray_diff", true};
+	{"GBU_31", NORMAL_MAP, "gbu_31_nm", true};
+	{"GBU_31", ROUGHNESS_METALLIC, "gbu_31_diff_roughmet", true};
+	{"mk_84", NORMAL_MAP, "mk_84_nm", true};
+	{"mk_84", ROUGHNESS_METALLIC, "mk_84_diff_roughmet", true};
+	{"GBU_10", DIFFUSE, "gbu_10_diff", true};
+	{"GBU_10", NORMAL_MAP, "gbu_10_nm", true};
+	{"GBU_10", ROUGHNESS_METALLIC, "gbu_10_diff_roughmet", true};
+	{"GBU_16", DIFFUSE, "gbu_16t_gray_diff", true};
+	{"GBU_16", NORMAL_MAP, "gbu_16t_nm", true};
+	{"GBU_16", ROUGHNESS_METALLIC, "gbu_16t_gray_diff_roughmet", true};
 	--Fuel Tanks
 	{"FPU_8A", 0 ,"FPU_8A_PukinDogs_CO",false};
 	{"FPU_8A", ROUGHNESS_METALLIC ,"FPU_8A_Diff_RoughMet",true};	

--- a/FA-18C_hornet/VFA-143 - 204 - Whiskeys -JTF CMDR/description.lua.bak
+++ b/FA-18C_hornet/VFA-143 - 204 - Whiskeys -JTF CMDR/description.lua.bak
@@ -16,187 +16,46 @@ livery = {
 	{"FPU_8A", 0 ,"FPU_8A_PukinDogs_CO",false};
 	{"FPU_8A", ROUGHNESS_METALLIC ,"FPU_8A_Diff_RoughMet",true};	
 	
-	--Nose Aircraft Numbers (USN)
-	--Left
-	{"F18C_BORT_NUMBER_NOSE_L_100", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_NOSE_L_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_L_10", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_NOSE_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_L_01", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_NOSE_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_NOSE_R_100", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_NOSE_R_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_R_10", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_NOSE_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_R_01", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_NOSE_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_R_01", DECAL ,"empty",true};	
-		
-	--Flap Aircraft Numbers (USN)
-	--Left
-	{"F18C_BORT_NUMBER_ZAK_L_100", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_ZAK_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_ZAK_L_10", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_ZAK_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_ZAK_L_01", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_ZAK_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_ZAK_R_100", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_ZAK_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_ZAK_R_10", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_ZAK_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_ZAK_R_01", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_ZAK_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_R_01", DECAL ,"empty",true};
+	--*NEW 2.8.4 Bort Numbers*
+	--USN_MODEX_NOSE
+	{"f18c1_number_nose_left"			, DIFFUSE				, "F18C_1_DIFF_VMFA_224_Bengals", false};
+	{"f18c1_number_nose_left"			, SPECULAR				, "F18C_1_DIF_RoughMet", false};
+	{"f18c1_number_nose_left"			, DECAL					, "empty", true};
+	{"f18c1_number_nose_right"			, DIFFUSE				, "F18C_1_DIFF_VMFA_224_Bengals", false};
+	{"f18c1_number_nose_right"			, SPECULAR				, "F18C_1_DIF_RoughMet", false};
+	{"f18c1_number_nose_right"			, DECAL					, "empty", true};
+	--RAAF /KAF/SWITZ_MODEX_FUSELAGE_FRONT_MID_BACK_GEAR_DOORS_SMALL
+	{"f18c1_number_F"					, DIFFUSE				, "F18C_1_DIFF_VMFA_224_Bengals", false};
+	{"f18c1_number_F"					, SPECULAR				, "F18C_1_DIF_RoughMet", false};
+	{"f18c1_number_F"					, DECAL					, "empty", true};
+	--KAF_MODEX_VERTICAL_STABILIZERS_AND_FLAPS_MODEX
+	{"f18c2_number_X"					, DIFFUSE				, "F18C_2_DIFF_VMFA_224_Bengals", false};
+	{"f18c2_number_X"					, SPECULAR				, "F18C_2_DIF_RoughMet", false};
+	{"f18c2_number_X"					, DECAL					, "empty", true};
+	--USN_MODEX_VERTICAL_STABILIZERS
+	{"f18c2_kil_left"					, DIFFUSE				, "F18C_2_DIFF_VMFA_224_Bengals", false};
+	{"f18c2_kil_left"					, SPECULAR				, "F18C_2_DIF_RoughMet", false};
+	{"f18c2_kil_left"					, DECAL					, "empty", true};
+	{"f18c2_kil_right"					, DIFFUSE				, "F18C_2_DIFF_VMFA_224_Bengals", false};
+	{"f18c2_kil_right"					, SPECULAR				, "F18C_2_DIF_RoughMet", false};
+	{"f18c2_kil_right"					, DECAL					, "empty", true};	
 	
-	--Vertical Stab Aircraft Numbers (USN)
-	--Left
-	{"F18C_BORT_NUMBER_KIL_L_100", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_L_10", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_L_01", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_L_01", DECAL ,"empty",true};	
-	--Right
-	{"F18C_BORT_NUMBER_KIL_R_100", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_R_10", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_R_01", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_R_01", DECAL ,"empty",true};		
-
-	--Nose Aircraft Numbers (KUWAIT)
-	--Left
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_100", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_10", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_01", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_100", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_10", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_01", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_01", DECAL ,"empty",true};		
 	
+	--(0.0 = ON, 1.0 OFF)
 
-	--Vertical Stab Numbers (KUWAIT)
-	--Right
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_100", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_10", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_01", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_100", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_10", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_01", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_01", DECAL ,"empty",true};		
-
-	--Nose Aircraft Numbers (FINLAND)
-	--Left
-	{"F18C_BORT_NUMBER_NOSE_fin_L_10", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_fin_L_01", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_NOSE_fin_R_10", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_fin_R_01", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_01", DECAL ,"empty",true};			
-
-	--Vertical Tail Numbers (SWITZERLAND)
-	--Right
-	{"F18C_BORT_NUMBER_KIL_Switz_R_100", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_10", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Switz_R_01", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_KIL_Switz_L_100", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_10", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Switz_L_01", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_01", DECAL ,"empty",true};
-
-	--Gear Door Numbers (RAAF)
-	--Right
-	{"F18C_BORT_NUMBER_STV_aus_R_10", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_STV_aus_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_STV_aus_R_01", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_STV_aus_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_STV_aus_L_10", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_STV_aus_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_STV_aus_L_01", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_STV_aus_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_L_01", DECAL ,"empty",true};		
-		
-	--Aft Fuselage Numbers (RAAF)
-	--Right
-	{"F18C_BORT_NUMBER_MTW_aus_R_10", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_MTW_aus_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_MTW_aus_R_01", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_MTW_aus_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_MTW_aus_L_10", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_MTW_aus_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_MTW_aus_L_01", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_MTW_aus_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_L_01", DECAL ,"empty",true};	
+	
 }
+
+custom_args = {
+	[0027] = 1.0, -- USN_MODEX_VERTICAL_STABILIZERS
+	[1000] = 1.0, -- USN_MODEX_FLAPS
+	[1001] = 1.0, -- USN_MODEX_NOSE
+	[1002] = 1.0, -- KUWAIT_MODEX_NOSE_AND_VERTICAL_STABILIZERS
+	[1003] = 1.0, -- AUSTRAILIA_MODEX_REAR_FUSELAGE_AND_GEAR_DOORS
+	[1004] = 1.0, -- FINLAND_MODEX_FORWARD_FUSELAGE
+	[1005] = 1.0, -- SWITZERLAND_MODEX_VERTICAL_STABILIZERS
+}
+
 name = "VFA-143 Pukin' Dogs - 204 - Whiskeys - JTF-13 Commander"
 countries = {"USA", "RUS", "FRA", "UKR", "SPN", "NETH", "TUR", "BEL", "GER", "NOR", "CAN", "DEN", "UK", "GRG", "ISR", "ABH", "RSO"}
 --By SkateZilla Graphics Studios 2018 (07.10.2018)

--- a/FA-18C_hornet/VFA-143 - 205 - Disco/description.lua
+++ b/FA-18C_hornet/VFA-143 - 205 - Disco/description.lua
@@ -12,6 +12,31 @@ livery = {
 	{"pilot_F18_patch", ROUGHNESS_METALLIC ,"../VFA-143Textures/Pilot_F18_Patch_PukinDogs_RoughMet",false};
 	{"pilot_F18_helmet", 0, "../VFA-143Textures/PILOT_F18_HELMET_VFA_DEFAULT", false};
 	
+	--Grey Naval bombs
+	{"GBU_12",	DIFFUSE			,	"gbu_12t_gray_diff", true};
+	{"GBU_12",	NORMAL_MAP			,	"gbu_12_nm", true};
+	{"GBU_12",	ROUGHNESS_METALLIC			,	"gbu_12_diff_roughmet", true};
+	{"MK_82", DIFFUSE, "mk_82t_grey_diff", true};
+	{"MK_82", NORMAL_MAP, "mk_82_nm", true};
+	{"MK_82", ROUGHNESS_METALLIC, "mk_82_diff_roughmet", true};
+	{"mk_83", DIFFUSE, "mk_83tgrey_diff", true};
+	{"mk_83", NORMAL_MAP, "mk_83_nm", true};
+	{"mk_83", ROUGHNESS_METALLIC, "mk_83_diff_roughmet", true};
+	{"GBU_38", DIFFUSE, "gbu_38t_diff", true};
+	{"GBU_38", NORMAL_MAP, "gbu_38_nm", true};
+	{"GBU_38", ROUGHNESS_METALLIC, "gbu_38_diff_roughmet", true};
+	{"GBU_31", DIFFUSE, "gbu_31t_gray_diff", true};
+	{"GBU_31", NORMAL_MAP, "gbu_31_nm", true};
+	{"GBU_31", ROUGHNESS_METALLIC, "gbu_31_diff_roughmet", true};
+	{"mk_84", NORMAL_MAP, "mk_84_nm", true};
+	{"mk_84", ROUGHNESS_METALLIC, "mk_84_diff_roughmet", true};
+	{"GBU_10", DIFFUSE, "gbu_10_diff", true};
+	{"GBU_10", NORMAL_MAP, "gbu_10_nm", true};
+	{"GBU_10", ROUGHNESS_METALLIC, "gbu_10_diff_roughmet", true};
+	{"GBU_16", DIFFUSE, "gbu_16t_gray_diff", true};
+	{"GBU_16", NORMAL_MAP, "gbu_16t_nm", true};
+	{"GBU_16", ROUGHNESS_METALLIC, "gbu_16t_gray_diff_roughmet", true};
+	
 	--Fuel Tanks
 	{"FPU_8A", 0 ,"../VFA-143Textures/FPU_8A_PukinDogs_Line",false};
 	{"FPU_8A", ROUGHNESS_METALLIC ,"FPU_8A_Diff_RoughMet",true};	

--- a/FA-18C_hornet/VFA-143 - 205 - Disco/description.lua.bak
+++ b/FA-18C_hornet/VFA-143 - 205 - Disco/description.lua.bak
@@ -56,6 +56,6 @@ custom_args = {
 	[1005] = 1.0, -- SWITZERLAND_MODEX_VERTICAL_STABILIZERS
 }
 
-name = "VFA-143 Pukin' Dogs - 207 - Disco"
+name = "VFA-143 Pukin' Dogs - 205 - Disco"
 countries = {"USA", "RUS", "FRA", "UKR", "SPN", "NETH", "TUR", "BEL", "GER", "NOR", "CAN", "DEN", "UK", "GRG", "ISR", "ABH", "RSO"}
 --By SkateZilla Graphics Studios 2018 (07.10.2018)

--- a/FA-18C_hornet/VFA-143 - 206 - Strider/description.lua
+++ b/FA-18C_hornet/VFA-143 - 206 - Strider/description.lua
@@ -12,6 +12,31 @@ livery = {
 	{"pilot_F18_patch", ROUGHNESS_METALLIC ,"../VFA-143Textures/Pilot_F18_Patch_PukinDogs_RoughMet",false};
 	{"pilot_F18_helmet", 0, "PILOT_F18_HELMET_Strider", false};
 	
+	--Grey Naval bombs
+	{"GBU_12",	DIFFUSE			,	"gbu_12t_gray_diff", true};
+	{"GBU_12",	NORMAL_MAP			,	"gbu_12_nm", true};
+	{"GBU_12",	ROUGHNESS_METALLIC			,	"gbu_12_diff_roughmet", true};
+	{"MK_82", DIFFUSE, "mk_82t_grey_diff", true};
+	{"MK_82", NORMAL_MAP, "mk_82_nm", true};
+	{"MK_82", ROUGHNESS_METALLIC, "mk_82_diff_roughmet", true};
+	{"mk_83", DIFFUSE, "mk_83tgrey_diff", true};
+	{"mk_83", NORMAL_MAP, "mk_83_nm", true};
+	{"mk_83", ROUGHNESS_METALLIC, "mk_83_diff_roughmet", true};
+	{"GBU_38", DIFFUSE, "gbu_38t_diff", true};
+	{"GBU_38", NORMAL_MAP, "gbu_38_nm", true};
+	{"GBU_38", ROUGHNESS_METALLIC, "gbu_38_diff_roughmet", true};
+	{"GBU_31", DIFFUSE, "gbu_31t_gray_diff", true};
+	{"GBU_31", NORMAL_MAP, "gbu_31_nm", true};
+	{"GBU_31", ROUGHNESS_METALLIC, "gbu_31_diff_roughmet", true};
+	{"mk_84", NORMAL_MAP, "mk_84_nm", true};
+	{"mk_84", ROUGHNESS_METALLIC, "mk_84_diff_roughmet", true};
+	{"GBU_10", DIFFUSE, "gbu_10_diff", true};
+	{"GBU_10", NORMAL_MAP, "gbu_10_nm", true};
+	{"GBU_10", ROUGHNESS_METALLIC, "gbu_10_diff_roughmet", true};
+	{"GBU_16", DIFFUSE, "gbu_16t_gray_diff", true};
+	{"GBU_16", NORMAL_MAP, "gbu_16t_nm", true};
+	{"GBU_16", ROUGHNESS_METALLIC, "gbu_16t_gray_diff_roughmet", true};
+	
 	--Fuel Tanks
 	{"FPU_8A", 0 ,"../VFA-143Textures/FPU_8A_PukinDogs_Line",false};
 	{"FPU_8A", ROUGHNESS_METALLIC ,"FPU_8A_Diff_RoughMet",true};	

--- a/FA-18C_hornet/VFA-143 - 206 - Strider/description.lua.bak
+++ b/FA-18C_hornet/VFA-143 - 206 - Strider/description.lua.bak
@@ -16,187 +16,46 @@ livery = {
 	{"FPU_8A", 0 ,"../VFA-143Textures/FPU_8A_PukinDogs_Line",false};
 	{"FPU_8A", ROUGHNESS_METALLIC ,"FPU_8A_Diff_RoughMet",true};	
 	
-	--Nose Aircraft Numbers (USN)
-	--Left
-	{"F18C_BORT_NUMBER_NOSE_L_100", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_NOSE_L_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_L_10", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_NOSE_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_L_01", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_NOSE_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_NOSE_R_100", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_NOSE_R_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_R_10", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_NOSE_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_R_01", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_NOSE_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_R_01", DECAL ,"empty",true};	
-		
-	--Flap Aircraft Numbers (USN)
-	--Left
-	{"F18C_BORT_NUMBER_ZAK_L_100", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_ZAK_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_ZAK_L_10", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_ZAK_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_ZAK_L_01", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_ZAK_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_ZAK_R_100", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_ZAK_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_ZAK_R_10", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_ZAK_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_ZAK_R_01", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_ZAK_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_R_01", DECAL ,"empty",true};
+	--*NEW 2.8.4 Bort Numbers*
+	--USN_MODEX_NOSE
+	{"f18c1_number_nose_left"			, DIFFUSE				, "F18C_1_DIFF_VFA143_PukinDogs_Line", false};
+	{"f18c1_number_nose_left"			, SPECULAR				, "F18C_1_DIF_RoughMet", false};
+	{"f18c1_number_nose_left"			, DECAL					, "empty", true};
+	{"f18c1_number_nose_right"			, DIFFUSE				, "F18C_1_DIFF_VFA143_PukinDogs_Line", false};
+	{"f18c1_number_nose_right"			, SPECULAR				, "F18C_1_DIF_RoughMet", false};
+	{"f18c1_number_nose_right"			, DECAL					, "empty", true};
+	--RAAF /KAF/SWITZ_MODEX_FUSELAGE_FRONT_MID_BACK_GEAR_DOORS_SMALL
+	{"f18c1_number_F"					, DIFFUSE				, "F18C_1_DIFF_VFA143_PukinDogs_Line", false};
+	{"f18c1_number_F"					, SPECULAR				, "F18C_1_DIF_RoughMet", false};
+	{"f18c1_number_F"					, DECAL					, "empty", true};
+	--KAF_MODEX_VERTICAL_STABILIZERS_AND_FLAPS_MODEX
+	{"f18c2_number_X"					, DIFFUSE				, "F18C_2_DIFF_VFA143_PukinDogs_Line", false};
+	{"f18c2_number_X"					, SPECULAR				, "F18C_2_DIF_RoughMet", false};
+	{"f18c2_number_X"					, DECAL					, "empty", true};
+	--USN_MODEX_VERTICAL_STABILIZERS
+	{"f18c2_kil_left"					, DIFFUSE				, "F18C_2_DIFF_VFA143_PukinDogs_Line", false};
+	{"f18c2_kil_left"					, SPECULAR				, "F18C_2_DIF_RoughMet", false};
+	{"f18c2_kil_left"					, DECAL					, "empty", true};
+	{"f18c2_kil_right"					, DIFFUSE				, "F18C_2_DIFF_VFA143_PukinDogs_Line", false};
+	{"f18c2_kil_right"					, SPECULAR				, "F18C_2_DIF_RoughMet", false};
+	{"f18c2_kil_right"					, DECAL					, "empty", true};	
 	
-	--Vertical Stab Aircraft Numbers (USN)
-	--Left
-	{"F18C_BORT_NUMBER_KIL_L_100", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_L_10", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_L_01", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_L_01", DECAL ,"empty",true};	
-	--Right
-	{"F18C_BORT_NUMBER_KIL_R_100", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_R_10", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_R_01", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_R_01", DECAL ,"empty",true};		
-
-	--Nose Aircraft Numbers (KUWAIT)
-	--Left
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_100", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_10", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_01", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_100", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_10", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_01", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_01", DECAL ,"empty",true};		
 	
+	--(0.0 = ON, 1.0 OFF)
 
-	--Vertical Stab Numbers (KUWAIT)
-	--Right
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_100", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_10", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_01", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_100", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_10", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_01", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_01", DECAL ,"empty",true};		
-
-	--Nose Aircraft Numbers (FINLAND)
-	--Left
-	{"F18C_BORT_NUMBER_NOSE_fin_L_10", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_fin_L_01", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_NOSE_fin_R_10", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_fin_R_01", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_01", DECAL ,"empty",true};			
-
-	--Vertical Tail Numbers (SWITZERLAND)
-	--Right
-	{"F18C_BORT_NUMBER_KIL_Switz_R_100", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_10", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Switz_R_01", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_KIL_Switz_L_100", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_10", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Switz_L_01", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_01", DECAL ,"empty",true};
-
-	--Gear Door Numbers (RAAF)
-	--Right
-	{"F18C_BORT_NUMBER_STV_aus_R_10", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_STV_aus_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_STV_aus_R_01", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_STV_aus_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_STV_aus_L_10", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_STV_aus_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_STV_aus_L_01", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_STV_aus_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_L_01", DECAL ,"empty",true};		
-		
-	--Aft Fuselage Numbers (RAAF)
-	--Right
-	{"F18C_BORT_NUMBER_MTW_aus_R_10", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_MTW_aus_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_MTW_aus_R_01", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_MTW_aus_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_MTW_aus_L_10", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_MTW_aus_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_MTW_aus_L_01", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_MTW_aus_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_L_01", DECAL ,"empty",true};	
+	
 }
+
+custom_args = {
+	[0027] = 1.0, -- USN_MODEX_VERTICAL_STABILIZERS
+	[1000] = 1.0, -- USN_MODEX_FLAPS
+	[1001] = 1.0, -- USN_MODEX_NOSE
+	[1002] = 1.0, -- KUWAIT_MODEX_NOSE_AND_VERTICAL_STABILIZERS
+	[1003] = 1.0, -- AUSTRAILIA_MODEX_REAR_FUSELAGE_AND_GEAR_DOORS
+	[1004] = 1.0, -- FINLAND_MODEX_FORWARD_FUSELAGE
+	[1005] = 1.0, -- SWITZERLAND_MODEX_VERTICAL_STABILIZERS
+}
+
 name = "VFA-143 Pukin' Dogs - 206 - Strider"
 countries = {"USA", "RUS", "FRA", "UKR", "SPN", "NETH", "TUR", "BEL", "GER", "NOR", "CAN", "DEN", "UK", "GRG", "ISR", "ABH", "RSO"}
 --By SkateZilla Graphics Studios 2018 (07.10.2018)

--- a/FA-18C_hornet/VFA-143 - 207 - Whiplash/description.lua
+++ b/FA-18C_hornet/VFA-143 - 207 - Whiplash/description.lua
@@ -12,6 +12,31 @@ livery = {
 	{"pilot_F18_patch", ROUGHNESS_METALLIC ,"../VFA-143Textures/Pilot_F18_Patch_PukinDogs_RoughMet",false};
 	{"pilot_F18_helmet", 0, "../VFA-143Textures/PILOT_F18_HELMET_VFA_DEFAULT", false};
 	
+	--Grey Naval bombs
+	{"GBU_12",	DIFFUSE			,	"gbu_12t_gray_diff", true};
+	{"GBU_12",	NORMAL_MAP			,	"gbu_12_nm", true};
+	{"GBU_12",	ROUGHNESS_METALLIC			,	"gbu_12_diff_roughmet", true};
+	{"MK_82", DIFFUSE, "mk_82t_grey_diff", true};
+	{"MK_82", NORMAL_MAP, "mk_82_nm", true};
+	{"MK_82", ROUGHNESS_METALLIC, "mk_82_diff_roughmet", true};
+	{"mk_83", DIFFUSE, "mk_83tgrey_diff", true};
+	{"mk_83", NORMAL_MAP, "mk_83_nm", true};
+	{"mk_83", ROUGHNESS_METALLIC, "mk_83_diff_roughmet", true};
+	{"GBU_38", DIFFUSE, "gbu_38t_diff", true};
+	{"GBU_38", NORMAL_MAP, "gbu_38_nm", true};
+	{"GBU_38", ROUGHNESS_METALLIC, "gbu_38_diff_roughmet", true};
+	{"GBU_31", DIFFUSE, "gbu_31t_gray_diff", true};
+	{"GBU_31", NORMAL_MAP, "gbu_31_nm", true};
+	{"GBU_31", ROUGHNESS_METALLIC, "gbu_31_diff_roughmet", true};
+	{"mk_84", NORMAL_MAP, "mk_84_nm", true};
+	{"mk_84", ROUGHNESS_METALLIC, "mk_84_diff_roughmet", true};
+	{"GBU_10", DIFFUSE, "gbu_10_diff", true};
+	{"GBU_10", NORMAL_MAP, "gbu_10_nm", true};
+	{"GBU_10", ROUGHNESS_METALLIC, "gbu_10_diff_roughmet", true};
+	{"GBU_16", DIFFUSE, "gbu_16t_gray_diff", true};
+	{"GBU_16", NORMAL_MAP, "gbu_16t_nm", true};
+	{"GBU_16", ROUGHNESS_METALLIC, "gbu_16t_gray_diff_roughmet", true};
+	
 	--Fuel Tanks
 	{"FPU_8A", 0 ,"../VFA-143Textures/FPU_8A_PukinDogs_Line",false};
 	{"FPU_8A", ROUGHNESS_METALLIC ,"FPU_8A_Diff_RoughMet",true};	

--- a/FA-18C_hornet/VFA-143 - 207 - Whiplash/description.lua.bak
+++ b/FA-18C_hornet/VFA-143 - 207 - Whiplash/description.lua.bak
@@ -56,6 +56,6 @@ custom_args = {
 	[1005] = 1.0, -- SWITZERLAND_MODEX_VERTICAL_STABILIZERS
 }
 
-name = "VFA-143 Pukin' Dogs - 205 - Disco"
+name = "VFA-143 Pukin' Dogs - 207 - Whiplash"
 countries = {"USA", "RUS", "FRA", "UKR", "SPN", "NETH", "TUR", "BEL", "GER", "NOR", "CAN", "DEN", "UK", "GRG", "ISR", "ABH", "RSO"}
 --By SkateZilla Graphics Studios 2018 (07.10.2018)

--- a/FA-18C_hornet/VFA-143 - 208 - Pulse/description.lua
+++ b/FA-18C_hornet/VFA-143 - 208 - Pulse/description.lua
@@ -12,6 +12,31 @@ livery = {
 	{"pilot_F18_patch", ROUGHNESS_METALLIC ,"../VFA-143Textures/Pilot_F18_Patch_PukinDogs_RoughMet",false};
 	{"pilot_F18_helmet", 0, "../VFA-143Textures/PILOT_F18_HELMET_VFA_DEFAULT", false};
 	
+	--Grey Naval bombs
+	{"GBU_12",	DIFFUSE			,	"gbu_12t_gray_diff", true};
+	{"GBU_12",	NORMAL_MAP			,	"gbu_12_nm", true};
+	{"GBU_12",	ROUGHNESS_METALLIC			,	"gbu_12_diff_roughmet", true};
+	{"MK_82", DIFFUSE, "mk_82t_grey_diff", true};
+	{"MK_82", NORMAL_MAP, "mk_82_nm", true};
+	{"MK_82", ROUGHNESS_METALLIC, "mk_82_diff_roughmet", true};
+	{"mk_83", DIFFUSE, "mk_83tgrey_diff", true};
+	{"mk_83", NORMAL_MAP, "mk_83_nm", true};
+	{"mk_83", ROUGHNESS_METALLIC, "mk_83_diff_roughmet", true};
+	{"GBU_38", DIFFUSE, "gbu_38t_diff", true};
+	{"GBU_38", NORMAL_MAP, "gbu_38_nm", true};
+	{"GBU_38", ROUGHNESS_METALLIC, "gbu_38_diff_roughmet", true};
+	{"GBU_31", DIFFUSE, "gbu_31t_gray_diff", true};
+	{"GBU_31", NORMAL_MAP, "gbu_31_nm", true};
+	{"GBU_31", ROUGHNESS_METALLIC, "gbu_31_diff_roughmet", true};
+	{"mk_84", NORMAL_MAP, "mk_84_nm", true};
+	{"mk_84", ROUGHNESS_METALLIC, "mk_84_diff_roughmet", true};
+	{"GBU_10", DIFFUSE, "gbu_10_diff", true};
+	{"GBU_10", NORMAL_MAP, "gbu_10_nm", true};
+	{"GBU_10", ROUGHNESS_METALLIC, "gbu_10_diff_roughmet", true};
+	{"GBU_16", DIFFUSE, "gbu_16t_gray_diff", true};
+	{"GBU_16", NORMAL_MAP, "gbu_16t_nm", true};
+	{"GBU_16", ROUGHNESS_METALLIC, "gbu_16t_gray_diff_roughmet", true};
+	
 	--Fuel Tanks
 	{"FPU_8A", 0 ,"../VFA-143Textures/FPU_8A_PukinDogs_Line",false};
 	{"FPU_8A", ROUGHNESS_METALLIC ,"FPU_8A_Diff_RoughMet",true};	

--- a/FA-18C_hornet/VFA-143 - 208 - Pulse/description.lua.bak
+++ b/FA-18C_hornet/VFA-143 - 208 - Pulse/description.lua.bak
@@ -56,6 +56,6 @@ custom_args = {
 	[1005] = 1.0, -- SWITZERLAND_MODEX_VERTICAL_STABILIZERS
 }
 
-name = "VFA-143 Pukin' Dogs - 210 - Murder Bug"
+name = "VFA-143 Pukin' Dogs - 208 - Pulse"
 countries = {"USA", "RUS", "FRA", "UKR", "SPN", "NETH", "TUR", "BEL", "GER", "NOR", "CAN", "DEN", "UK", "GRG", "ISR", "ABH", "RSO"}
 --By SkateZilla Graphics Studios 2018 (07.10.2018)

--- a/FA-18C_hornet/VFA-143 - 210 - Murder Bug/description.lua
+++ b/FA-18C_hornet/VFA-143 - 210 - Murder Bug/description.lua
@@ -12,6 +12,31 @@ livery = {
 	{"pilot_F18_patch", ROUGHNESS_METALLIC ,"../VFA-143Textures/Pilot_F18_Patch_PukinDogs_RoughMet",false};
 	{"pilot_F18_helmet", 0, "../VFA-143Textures/PILOT_F18_HELMET_VFA_DEFAULT", false};
 	
+	--Grey Naval bombs
+	{"GBU_12",	DIFFUSE			,	"gbu_12t_gray_diff", true};
+	{"GBU_12",	NORMAL_MAP			,	"gbu_12_nm", true};
+	{"GBU_12",	ROUGHNESS_METALLIC			,	"gbu_12_diff_roughmet", true};
+	{"MK_82", DIFFUSE, "mk_82t_grey_diff", true};
+	{"MK_82", NORMAL_MAP, "mk_82_nm", true};
+	{"MK_82", ROUGHNESS_METALLIC, "mk_82_diff_roughmet", true};
+	{"mk_83", DIFFUSE, "mk_83tgrey_diff", true};
+	{"mk_83", NORMAL_MAP, "mk_83_nm", true};
+	{"mk_83", ROUGHNESS_METALLIC, "mk_83_diff_roughmet", true};
+	{"GBU_38", DIFFUSE, "gbu_38t_diff", true};
+	{"GBU_38", NORMAL_MAP, "gbu_38_nm", true};
+	{"GBU_38", ROUGHNESS_METALLIC, "gbu_38_diff_roughmet", true};
+	{"GBU_31", DIFFUSE, "gbu_31t_gray_diff", true};
+	{"GBU_31", NORMAL_MAP, "gbu_31_nm", true};
+	{"GBU_31", ROUGHNESS_METALLIC, "gbu_31_diff_roughmet", true};
+	{"mk_84", NORMAL_MAP, "mk_84_nm", true};
+	{"mk_84", ROUGHNESS_METALLIC, "mk_84_diff_roughmet", true};
+	{"GBU_10", DIFFUSE, "gbu_10_diff", true};
+	{"GBU_10", NORMAL_MAP, "gbu_10_nm", true};
+	{"GBU_10", ROUGHNESS_METALLIC, "gbu_10_diff_roughmet", true};
+	{"GBU_16", DIFFUSE, "gbu_16t_gray_diff", true};
+	{"GBU_16", NORMAL_MAP, "gbu_16t_nm", true};
+	{"GBU_16", ROUGHNESS_METALLIC, "gbu_16t_gray_diff_roughmet", true};
+	
 	--Fuel Tanks
 	{"FPU_8A", 0 ,"../VFA-143Textures/FPU_8A_PukinDogs_Line",false};
 	{"FPU_8A", ROUGHNESS_METALLIC ,"FPU_8A_Diff_RoughMet",true};	

--- a/FA-18C_hornet/VFA-143 - 210 - Murder Bug/description.lua.bak
+++ b/FA-18C_hornet/VFA-143 - 210 - Murder Bug/description.lua.bak
@@ -16,187 +16,46 @@ livery = {
 	{"FPU_8A", 0 ,"../VFA-143Textures/FPU_8A_PukinDogs_Line",false};
 	{"FPU_8A", ROUGHNESS_METALLIC ,"FPU_8A_Diff_RoughMet",true};	
 	
-	--Nose Aircraft Numbers (USN)
-	--Left
-	{"F18C_BORT_NUMBER_NOSE_L_100", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_NOSE_L_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_L_10", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_NOSE_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_L_01", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_NOSE_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_NOSE_R_100", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_NOSE_R_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_R_10", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_NOSE_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_R_01", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_NOSE_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_R_01", DECAL ,"empty",true};	
-		
-	--Flap Aircraft Numbers (USN)
-	--Left
-	{"F18C_BORT_NUMBER_ZAK_L_100", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_ZAK_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_ZAK_L_10", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_ZAK_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_ZAK_L_01", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_ZAK_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_ZAK_R_100", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_ZAK_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_ZAK_R_10", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_ZAK_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_ZAK_R_01", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_ZAK_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_R_01", DECAL ,"empty",true};
+	--*NEW 2.8.4 Bort Numbers*
+	--USN_MODEX_NOSE
+	{"f18c1_number_nose_left"			, DIFFUSE				, "F18C_1_DIFF_VFA143_PukinDogs_Line", false};
+	{"f18c1_number_nose_left"			, SPECULAR				, "F18C_1_DIF_RoughMet", false};
+	{"f18c1_number_nose_left"			, DECAL					, "empty", true};
+	{"f18c1_number_nose_right"			, DIFFUSE				, "F18C_1_DIFF_VFA143_PukinDogs_Line", false};
+	{"f18c1_number_nose_right"			, SPECULAR				, "F18C_1_DIF_RoughMet", false};
+	{"f18c1_number_nose_right"			, DECAL					, "empty", true};
+	--RAAF /KAF/SWITZ_MODEX_FUSELAGE_FRONT_MID_BACK_GEAR_DOORS_SMALL
+	{"f18c1_number_F"					, DIFFUSE				, "F18C_1_DIFF_VFA143_PukinDogs_Line", false};
+	{"f18c1_number_F"					, SPECULAR				, "F18C_1_DIF_RoughMet", false};
+	{"f18c1_number_F"					, DECAL					, "empty", true};
+	--KAF_MODEX_VERTICAL_STABILIZERS_AND_FLAPS_MODEX
+	{"f18c2_number_X"					, DIFFUSE				, "F18C_2_DIFF_VFA143_PukinDogs_Line", false};
+	{"f18c2_number_X"					, SPECULAR				, "F18C_2_DIF_RoughMet", false};
+	{"f18c2_number_X"					, DECAL					, "empty", true};
+	--USN_MODEX_VERTICAL_STABILIZERS
+	{"f18c2_kil_left"					, DIFFUSE				, "F18C_2_DIFF_VFA143_PukinDogs_Line", false};
+	{"f18c2_kil_left"					, SPECULAR				, "F18C_2_DIF_RoughMet", false};
+	{"f18c2_kil_left"					, DECAL					, "empty", true};
+	{"f18c2_kil_right"					, DIFFUSE				, "F18C_2_DIFF_VFA143_PukinDogs_Line", false};
+	{"f18c2_kil_right"					, SPECULAR				, "F18C_2_DIF_RoughMet", false};
+	{"f18c2_kil_right"					, DECAL					, "empty", true};	
 	
-	--Vertical Stab Aircraft Numbers (USN)
-	--Left
-	{"F18C_BORT_NUMBER_KIL_L_100", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_L_10", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_L_01", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_L_01", DECAL ,"empty",true};	
-	--Right
-	{"F18C_BORT_NUMBER_KIL_R_100", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_R_10", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_R_01", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_R_01", DECAL ,"empty",true};		
-
-	--Nose Aircraft Numbers (KUWAIT)
-	--Left
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_100", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_10", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_01", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_100", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_10", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_01", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_01", DECAL ,"empty",true};		
 	
+	--(0.0 = ON, 1.0 OFF)
 
-	--Vertical Stab Numbers (KUWAIT)
-	--Right
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_100", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_10", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_01", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_100", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_10", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_01", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_01", DECAL ,"empty",true};		
-
-	--Nose Aircraft Numbers (FINLAND)
-	--Left
-	{"F18C_BORT_NUMBER_NOSE_fin_L_10", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_fin_L_01", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_NOSE_fin_R_10", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_fin_R_01", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_01", DECAL ,"empty",true};			
-
-	--Vertical Tail Numbers (SWITZERLAND)
-	--Right
-	{"F18C_BORT_NUMBER_KIL_Switz_R_100", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_10", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Switz_R_01", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_KIL_Switz_L_100", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_10", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Switz_L_01", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_01", DECAL ,"empty",true};
-
-	--Gear Door Numbers (RAAF)
-	--Right
-	{"F18C_BORT_NUMBER_STV_aus_R_10", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_STV_aus_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_STV_aus_R_01", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_STV_aus_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_STV_aus_L_10", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_STV_aus_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_STV_aus_L_01", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_STV_aus_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_L_01", DECAL ,"empty",true};		
-		
-	--Aft Fuselage Numbers (RAAF)
-	--Right
-	{"F18C_BORT_NUMBER_MTW_aus_R_10", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_MTW_aus_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_MTW_aus_R_01", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_MTW_aus_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_MTW_aus_L_10", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_MTW_aus_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_MTW_aus_L_01", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_MTW_aus_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_L_01", DECAL ,"empty",true};	
+	
 }
+
+custom_args = {
+	[0027] = 1.0, -- USN_MODEX_VERTICAL_STABILIZERS
+	[1000] = 1.0, -- USN_MODEX_FLAPS
+	[1001] = 1.0, -- USN_MODEX_NOSE
+	[1002] = 1.0, -- KUWAIT_MODEX_NOSE_AND_VERTICAL_STABILIZERS
+	[1003] = 1.0, -- AUSTRAILIA_MODEX_REAR_FUSELAGE_AND_GEAR_DOORS
+	[1004] = 1.0, -- FINLAND_MODEX_FORWARD_FUSELAGE
+	[1005] = 1.0, -- SWITZERLAND_MODEX_VERTICAL_STABILIZERS
+}
+
 name = "VFA-143 Pukin' Dogs - 210 - Murder Bug"
 countries = {"USA", "RUS", "FRA", "UKR", "SPN", "NETH", "TUR", "BEL", "GER", "NOR", "CAN", "DEN", "UK", "GRG", "ISR", "ABH", "RSO"}
 --By SkateZilla Graphics Studios 2018 (07.10.2018)

--- a/FA-18C_hornet/VFA-143 - 212 -  Fenrir/description.lua
+++ b/FA-18C_hornet/VFA-143 - 212 -  Fenrir/description.lua
@@ -12,6 +12,31 @@ livery = {
 	{"pilot_F18_patch", ROUGHNESS_METALLIC ,"../VFA-143Textures/Pilot_F18_Patch_PukinDogs_RoughMet",false};
 	{"pilot_F18_helmet", 0, "Fenrir_Helmet", false};
 	
+	--Grey Naval bombs
+	{"GBU_12",	DIFFUSE			,	"gbu_12t_gray_diff", true};
+	{"GBU_12",	NORMAL_MAP			,	"gbu_12_nm", true};
+	{"GBU_12",	ROUGHNESS_METALLIC			,	"gbu_12_diff_roughmet", true};
+	{"MK_82", DIFFUSE, "mk_82t_grey_diff", true};
+	{"MK_82", NORMAL_MAP, "mk_82_nm", true};
+	{"MK_82", ROUGHNESS_METALLIC, "mk_82_diff_roughmet", true};
+	{"mk_83", DIFFUSE, "mk_83tgrey_diff", true};
+	{"mk_83", NORMAL_MAP, "mk_83_nm", true};
+	{"mk_83", ROUGHNESS_METALLIC, "mk_83_diff_roughmet", true};
+	{"GBU_38", DIFFUSE, "gbu_38t_diff", true};
+	{"GBU_38", NORMAL_MAP, "gbu_38_nm", true};
+	{"GBU_38", ROUGHNESS_METALLIC, "gbu_38_diff_roughmet", true};
+	{"GBU_31", DIFFUSE, "gbu_31t_gray_diff", true};
+	{"GBU_31", NORMAL_MAP, "gbu_31_nm", true};
+	{"GBU_31", ROUGHNESS_METALLIC, "gbu_31_diff_roughmet", true};
+	{"mk_84", NORMAL_MAP, "mk_84_nm", true};
+	{"mk_84", ROUGHNESS_METALLIC, "mk_84_diff_roughmet", true};
+	{"GBU_10", DIFFUSE, "gbu_10_diff", true};
+	{"GBU_10", NORMAL_MAP, "gbu_10_nm", true};
+	{"GBU_10", ROUGHNESS_METALLIC, "gbu_10_diff_roughmet", true};
+	{"GBU_16", DIFFUSE, "gbu_16t_gray_diff", true};
+	{"GBU_16", NORMAL_MAP, "gbu_16t_nm", true};
+	{"GBU_16", ROUGHNESS_METALLIC, "gbu_16t_gray_diff_roughmet", true};
+	
 	--Fuel Tanks
 	{"FPU_8A", 0 ,"../VFA-143Textures/FPU_8A_PukinDogs_Line",false};
 	{"FPU_8A", ROUGHNESS_METALLIC ,"FPU_8A_Diff_RoughMet",true};	

--- a/FA-18C_hornet/VFA-143 - 212 -  Fenrir/description.lua.bak
+++ b/FA-18C_hornet/VFA-143 - 212 -  Fenrir/description.lua.bak
@@ -16,187 +16,46 @@ livery = {
 	{"FPU_8A", 0 ,"../VFA-143Textures/FPU_8A_PukinDogs_Line",false};
 	{"FPU_8A", ROUGHNESS_METALLIC ,"FPU_8A_Diff_RoughMet",true};	
 	
-	--Nose Aircraft Numbers (USN)
-	--Left
-	{"F18C_BORT_NUMBER_NOSE_L_100", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_NOSE_L_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_L_10", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_NOSE_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_L_01", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_NOSE_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_NOSE_R_100", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_NOSE_R_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_R_10", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_NOSE_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_R_01", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_NOSE_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_R_01", DECAL ,"empty",true};	
-		
-	--Flap Aircraft Numbers (USN)
-	--Left
-	{"F18C_BORT_NUMBER_ZAK_L_100", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_ZAK_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_ZAK_L_10", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_ZAK_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_ZAK_L_01", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_ZAK_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_ZAK_R_100", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_ZAK_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_ZAK_R_10", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_ZAK_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_ZAK_R_01", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_ZAK_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_R_01", DECAL ,"empty",true};
+	--*NEW 2.8.4 Bort Numbers*
+	--USN_MODEX_NOSE
+	{"f18c1_number_nose_left"			, DIFFUSE				, "F18C_1_DIFF_VFA143_PukinDogs_Line", false};
+	{"f18c1_number_nose_left"			, SPECULAR				, "F18C_1_DIF_RoughMet", false};
+	{"f18c1_number_nose_left"			, DECAL					, "empty", true};
+	{"f18c1_number_nose_right"			, DIFFUSE				, "F18C_1_DIFF_VFA143_PukinDogs_Line", false};
+	{"f18c1_number_nose_right"			, SPECULAR				, "F18C_1_DIF_RoughMet", false};
+	{"f18c1_number_nose_right"			, DECAL					, "empty", true};
+	--RAAF /KAF/SWITZ_MODEX_FUSELAGE_FRONT_MID_BACK_GEAR_DOORS_SMALL
+	{"f18c1_number_F"					, DIFFUSE				, "F18C_1_DIFF_VFA143_PukinDogs_Line", false};
+	{"f18c1_number_F"					, SPECULAR				, "F18C_1_DIF_RoughMet", false};
+	{"f18c1_number_F"					, DECAL					, "empty", true};
+	--KAF_MODEX_VERTICAL_STABILIZERS_AND_FLAPS_MODEX
+	{"f18c2_number_X"					, DIFFUSE				, "F18C_2_DIFF_VFA143_PukinDogs_Line", false};
+	{"f18c2_number_X"					, SPECULAR				, "F18C_2_DIF_RoughMet", false};
+	{"f18c2_number_X"					, DECAL					, "empty", true};
+	--USN_MODEX_VERTICAL_STABILIZERS
+	{"f18c2_kil_left"					, DIFFUSE				, "F18C_2_DIFF_VFA143_PukinDogs_Line", false};
+	{"f18c2_kil_left"					, SPECULAR				, "F18C_2_DIF_RoughMet", false};
+	{"f18c2_kil_left"					, DECAL					, "empty", true};
+	{"f18c2_kil_right"					, DIFFUSE				, "F18C_2_DIFF_VFA143_PukinDogs_Line", false};
+	{"f18c2_kil_right"					, SPECULAR				, "F18C_2_DIF_RoughMet", false};
+	{"f18c2_kil_right"					, DECAL					, "empty", true};	
 	
-	--Vertical Stab Aircraft Numbers (USN)
-	--Left
-	{"F18C_BORT_NUMBER_KIL_L_100", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_L_10", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_L_01", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_L_01", DECAL ,"empty",true};	
-	--Right
-	{"F18C_BORT_NUMBER_KIL_R_100", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_R_10", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_R_01", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_R_01", DECAL ,"empty",true};		
-
-	--Nose Aircraft Numbers (KUWAIT)
-	--Left
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_100", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_10", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_01", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_100", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_10", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_01", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_01", DECAL ,"empty",true};		
 	
+	--(0.0 = ON, 1.0 OFF)
 
-	--Vertical Stab Numbers (KUWAIT)
-	--Right
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_100", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_10", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_01", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_100", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_10", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_01", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_01", DECAL ,"empty",true};		
-
-	--Nose Aircraft Numbers (FINLAND)
-	--Left
-	{"F18C_BORT_NUMBER_NOSE_fin_L_10", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_fin_L_01", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_NOSE_fin_R_10", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_fin_R_01", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_01", DECAL ,"empty",true};			
-
-	--Vertical Tail Numbers (SWITZERLAND)
-	--Right
-	{"F18C_BORT_NUMBER_KIL_Switz_R_100", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_10", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Switz_R_01", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_KIL_Switz_L_100", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_10", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Switz_L_01", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_01", DECAL ,"empty",true};
-
-	--Gear Door Numbers (RAAF)
-	--Right
-	{"F18C_BORT_NUMBER_STV_aus_R_10", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_STV_aus_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_STV_aus_R_01", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_STV_aus_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_STV_aus_L_10", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_STV_aus_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_STV_aus_L_01", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_STV_aus_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_L_01", DECAL ,"empty",true};		
-		
-	--Aft Fuselage Numbers (RAAF)
-	--Right
-	{"F18C_BORT_NUMBER_MTW_aus_R_10", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_MTW_aus_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_MTW_aus_R_01", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_MTW_aus_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_MTW_aus_L_10", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_MTW_aus_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_MTW_aus_L_01", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_MTW_aus_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_L_01", DECAL ,"empty",true};	
+	
 }
+
+custom_args = {
+	[0027] = 1.0, -- USN_MODEX_VERTICAL_STABILIZERS
+	[1000] = 1.0, -- USN_MODEX_FLAPS
+	[1001] = 1.0, -- USN_MODEX_NOSE
+	[1002] = 1.0, -- KUWAIT_MODEX_NOSE_AND_VERTICAL_STABILIZERS
+	[1003] = 1.0, -- AUSTRAILIA_MODEX_REAR_FUSELAGE_AND_GEAR_DOORS
+	[1004] = 1.0, -- FINLAND_MODEX_FORWARD_FUSELAGE
+	[1005] = 1.0, -- SWITZERLAND_MODEX_VERTICAL_STABILIZERS
+}
+
 name = "VFA-143 Pukin' Dogs - 212 - Fenrir"
 countries = {"USA", "RUS", "FRA", "UKR", "SPN", "NETH", "TUR", "BEL", "GER", "NOR", "CAN", "DEN", "UK", "GRG", "ISR", "ABH", "RSO"}
 --By SkateZilla Graphics Studios 2018 (07.10.2018)

--- a/FA-18C_hornet/VFA-143 - 217 - Doc/description.lua
+++ b/FA-18C_hornet/VFA-143 - 217 - Doc/description.lua
@@ -12,6 +12,31 @@ livery = {
 	{"pilot_F18_patch", ROUGHNESS_METALLIC ,"../VFA-143Textures/Pilot_F18_Patch_PukinDogs_RoughMet",false};
 	{"pilot_F18_helmet", 0, "../VFA-143Textures/PILOT_F18_HELMET_VFA_DEFAULT", false};
 	
+	--Grey Naval bombs
+	{"GBU_12",	DIFFUSE			,	"gbu_12t_gray_diff", true};
+	{"GBU_12",	NORMAL_MAP			,	"gbu_12_nm", true};
+	{"GBU_12",	ROUGHNESS_METALLIC			,	"gbu_12_diff_roughmet", true};
+	{"MK_82", DIFFUSE, "mk_82t_grey_diff", true};
+	{"MK_82", NORMAL_MAP, "mk_82_nm", true};
+	{"MK_82", ROUGHNESS_METALLIC, "mk_82_diff_roughmet", true};
+	{"mk_83", DIFFUSE, "mk_83tgrey_diff", true};
+	{"mk_83", NORMAL_MAP, "mk_83_nm", true};
+	{"mk_83", ROUGHNESS_METALLIC, "mk_83_diff_roughmet", true};
+	{"GBU_38", DIFFUSE, "gbu_38t_diff", true};
+	{"GBU_38", NORMAL_MAP, "gbu_38_nm", true};
+	{"GBU_38", ROUGHNESS_METALLIC, "gbu_38_diff_roughmet", true};
+	{"GBU_31", DIFFUSE, "gbu_31t_gray_diff", true};
+	{"GBU_31", NORMAL_MAP, "gbu_31_nm", true};
+	{"GBU_31", ROUGHNESS_METALLIC, "gbu_31_diff_roughmet", true};
+	{"mk_84", NORMAL_MAP, "mk_84_nm", true};
+	{"mk_84", ROUGHNESS_METALLIC, "mk_84_diff_roughmet", true};
+	{"GBU_10", DIFFUSE, "gbu_10_diff", true};
+	{"GBU_10", NORMAL_MAP, "gbu_10_nm", true};
+	{"GBU_10", ROUGHNESS_METALLIC, "gbu_10_diff_roughmet", true};
+	{"GBU_16", DIFFUSE, "gbu_16t_gray_diff", true};
+	{"GBU_16", NORMAL_MAP, "gbu_16t_nm", true};
+	{"GBU_16", ROUGHNESS_METALLIC, "gbu_16t_gray_diff_roughmet", true};
+	
 	--Fuel Tanks
 	{"FPU_8A", 0 ,"../VFA-143Textures/FPU_8A_PukinDogs_Line",false};
 	{"FPU_8A", ROUGHNESS_METALLIC ,"FPU_8A_Diff_RoughMet",true};	

--- a/FA-18C_hornet/VFA-143 - 217 - Doc/description.lua.bak
+++ b/FA-18C_hornet/VFA-143 - 217 - Doc/description.lua.bak
@@ -16,187 +16,46 @@ livery = {
 	{"FPU_8A", 0 ,"../VFA-143Textures/FPU_8A_PukinDogs_Line",false};
 	{"FPU_8A", ROUGHNESS_METALLIC ,"FPU_8A_Diff_RoughMet",true};	
 	
-	--Nose Aircraft Numbers (USN)
-	--Left
-	{"F18C_BORT_NUMBER_NOSE_L_100", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_NOSE_L_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_L_10", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_NOSE_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_L_01", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_NOSE_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_NOSE_R_100", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_NOSE_R_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_R_10", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_NOSE_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_R_01", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_NOSE_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_R_01", DECAL ,"empty",true};	
-		
-	--Flap Aircraft Numbers (USN)
-	--Left
-	{"F18C_BORT_NUMBER_ZAK_L_100", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_ZAK_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_ZAK_L_10", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_ZAK_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_ZAK_L_01", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_ZAK_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_ZAK_R_100", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_ZAK_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_ZAK_R_10", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_ZAK_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_ZAK_R_01", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_ZAK_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_R_01", DECAL ,"empty",true};
+	--*NEW 2.8.4 Bort Numbers*
+	--USN_MODEX_NOSE
+	{"f18c1_number_nose_left"			, DIFFUSE				, "F18C_1_DIFF_VFA143_PukinDogs_Line", false};
+	{"f18c1_number_nose_left"			, SPECULAR				, "F18C_1_DIF_RoughMet", false};
+	{"f18c1_number_nose_left"			, DECAL					, "empty", true};
+	{"f18c1_number_nose_right"			, DIFFUSE				, "F18C_1_DIFF_VFA143_PukinDogs_Line", false};
+	{"f18c1_number_nose_right"			, SPECULAR				, "F18C_1_DIF_RoughMet", false};
+	{"f18c1_number_nose_right"			, DECAL					, "empty", true};
+	--RAAF /KAF/SWITZ_MODEX_FUSELAGE_FRONT_MID_BACK_GEAR_DOORS_SMALL
+	{"f18c1_number_F"					, DIFFUSE				, "F18C_1_DIFF_VFA143_PukinDogs_Line", false};
+	{"f18c1_number_F"					, SPECULAR				, "F18C_1_DIF_RoughMet", false};
+	{"f18c1_number_F"					, DECAL					, "empty", true};
+	--KAF_MODEX_VERTICAL_STABILIZERS_AND_FLAPS_MODEX
+	{"f18c2_number_X"					, DIFFUSE				, "F18C_2_DIFF_VFA143_PukinDogs_Line", false};
+	{"f18c2_number_X"					, SPECULAR				, "F18C_2_DIF_RoughMet", false};
+	{"f18c2_number_X"					, DECAL					, "empty", true};
+	--USN_MODEX_VERTICAL_STABILIZERS
+	{"f18c2_kil_left"					, DIFFUSE				, "F18C_2_DIFF_VFA143_PukinDogs_Line", false};
+	{"f18c2_kil_left"					, SPECULAR				, "F18C_2_DIF_RoughMet", false};
+	{"f18c2_kil_left"					, DECAL					, "empty", true};
+	{"f18c2_kil_right"					, DIFFUSE				, "F18C_2_DIFF_VFA143_PukinDogs_Line", false};
+	{"f18c2_kil_right"					, SPECULAR				, "F18C_2_DIF_RoughMet", false};
+	{"f18c2_kil_right"					, DECAL					, "empty", true};	
 	
-	--Vertical Stab Aircraft Numbers (USN)
-	--Left
-	{"F18C_BORT_NUMBER_KIL_L_100", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_L_10", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_L_01", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_L_01", DECAL ,"empty",true};	
-	--Right
-	{"F18C_BORT_NUMBER_KIL_R_100", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_R_10", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_R_01", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_R_01", DECAL ,"empty",true};		
-
-	--Nose Aircraft Numbers (KUWAIT)
-	--Left
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_100", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_10", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_01", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_100", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_10", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_01", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_01", DECAL ,"empty",true};		
 	
+	--(0.0 = ON, 1.0 OFF)
 
-	--Vertical Stab Numbers (KUWAIT)
-	--Right
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_100", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_10", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_01", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_100", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_10", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_01", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_01", DECAL ,"empty",true};		
-
-	--Nose Aircraft Numbers (FINLAND)
-	--Left
-	{"F18C_BORT_NUMBER_NOSE_fin_L_10", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_fin_L_01", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_NOSE_fin_R_10", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_fin_R_01", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_01", DECAL ,"empty",true};			
-
-	--Vertical Tail Numbers (SWITZERLAND)
-	--Right
-	{"F18C_BORT_NUMBER_KIL_Switz_R_100", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_10", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Switz_R_01", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_KIL_Switz_L_100", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_10", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Switz_L_01", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_01", DECAL ,"empty",true};
-
-	--Gear Door Numbers (RAAF)
-	--Right
-	{"F18C_BORT_NUMBER_STV_aus_R_10", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_STV_aus_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_STV_aus_R_01", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_STV_aus_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_STV_aus_L_10", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_STV_aus_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_STV_aus_L_01", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_STV_aus_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_L_01", DECAL ,"empty",true};		
-		
-	--Aft Fuselage Numbers (RAAF)
-	--Right
-	{"F18C_BORT_NUMBER_MTW_aus_R_10", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_MTW_aus_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_MTW_aus_R_01", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_MTW_aus_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_MTW_aus_L_10", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_MTW_aus_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_MTW_aus_L_01", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_Line",false};
-	{"F18C_BORT_NUMBER_MTW_aus_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_L_01", DECAL ,"empty",true};	
+	
 }
+
+custom_args = {
+	[0027] = 1.0, -- USN_MODEX_VERTICAL_STABILIZERS
+	[1000] = 1.0, -- USN_MODEX_FLAPS
+	[1001] = 1.0, -- USN_MODEX_NOSE
+	[1002] = 1.0, -- KUWAIT_MODEX_NOSE_AND_VERTICAL_STABILIZERS
+	[1003] = 1.0, -- AUSTRAILIA_MODEX_REAR_FUSELAGE_AND_GEAR_DOORS
+	[1004] = 1.0, -- FINLAND_MODEX_FORWARD_FUSELAGE
+	[1005] = 1.0, -- SWITZERLAND_MODEX_VERTICAL_STABILIZERS
+}
+
 name = "VFA-143 Pukin' Dogs - 217 - Doc"
 countries = {"USA", "RUS", "FRA", "UKR", "SPN", "NETH", "TUR", "BEL", "GER", "NOR", "CAN", "DEN", "UK", "GRG", "ISR", "ABH", "RSO"}
 --By SkateZilla Graphics Studios 2018 (07.10.2018)

--- a/FA-18C_hornet/VFA-143 - 220 - Apollo - Dep CMDR/description.lua
+++ b/FA-18C_hornet/VFA-143 - 220 - Apollo - Dep CMDR/description.lua
@@ -12,6 +12,31 @@ livery = {
 	{"pilot_F18_patch", ROUGHNESS_METALLIC ,"Pilot_F18_Patch_PukinDogs_RoughMet",false};
 	{"pilot_F18_helmet", 0, "../VFA-143Textures/Helmets/pilot_F18_helmet_APOLLO", false};
 	
+	--Grey Naval bombs
+	{"GBU_12",	DIFFUSE			,	"gbu_12t_gray_diff", true};
+	{"GBU_12",	NORMAL_MAP			,	"gbu_12_nm", true};
+	{"GBU_12",	ROUGHNESS_METALLIC			,	"gbu_12_diff_roughmet", true};
+	{"MK_82", DIFFUSE, "mk_82t_grey_diff", true};
+	{"MK_82", NORMAL_MAP, "mk_82_nm", true};
+	{"MK_82", ROUGHNESS_METALLIC, "mk_82_diff_roughmet", true};
+	{"mk_83", DIFFUSE, "mk_83tgrey_diff", true};
+	{"mk_83", NORMAL_MAP, "mk_83_nm", true};
+	{"mk_83", ROUGHNESS_METALLIC, "mk_83_diff_roughmet", true};
+	{"GBU_38", DIFFUSE, "gbu_38t_diff", true};
+	{"GBU_38", NORMAL_MAP, "gbu_38_nm", true};
+	{"GBU_38", ROUGHNESS_METALLIC, "gbu_38_diff_roughmet", true};
+	{"GBU_31", DIFFUSE, "gbu_31t_gray_diff", true};
+	{"GBU_31", NORMAL_MAP, "gbu_31_nm", true};
+	{"GBU_31", ROUGHNESS_METALLIC, "gbu_31_diff_roughmet", true};
+	{"mk_84", NORMAL_MAP, "mk_84_nm", true};
+	{"mk_84", ROUGHNESS_METALLIC, "mk_84_diff_roughmet", true};
+	{"GBU_10", DIFFUSE, "gbu_10_diff", true};
+	{"GBU_10", NORMAL_MAP, "gbu_10_nm", true};
+	{"GBU_10", ROUGHNESS_METALLIC, "gbu_10_diff_roughmet", true};
+	{"GBU_16", DIFFUSE, "gbu_16t_gray_diff", true};
+	{"GBU_16", NORMAL_MAP, "gbu_16t_nm", true};
+	{"GBU_16", ROUGHNESS_METALLIC, "gbu_16t_gray_diff_roughmet", true};
+	
 	--Fuel Tanks
 	{"FPU_8A", 0 ,"FPU_8A_PukinDogs_CO",false};
 	{"FPU_8A", ROUGHNESS_METALLIC ,"FPU_8A_Diff_RoughMet",true};

--- a/FA-18C_hornet/VFA-143 - 220 - Apollo - Dep CMDR/description.lua.bak
+++ b/FA-18C_hornet/VFA-143 - 220 - Apollo - Dep CMDR/description.lua.bak
@@ -21,187 +21,46 @@ livery = {
     --{"f18c_stay", 1, "f18c_1_diff_stay_nm", true};
     --{"f18c_stay", 2, "f18c_1_diff_stay_dif_roughmet", true};
 	
-	--Nose Aircraft Numbers (USN)
-	--Left
-	{"F18C_BORT_NUMBER_NOSE_L_100", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_CAG",false};
-	{"F18C_BORT_NUMBER_NOSE_L_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_L_10", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_CAG",false};
-	{"F18C_BORT_NUMBER_NOSE_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_L_01", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_CAG",false};
-	{"F18C_BORT_NUMBER_NOSE_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_NOSE_R_100", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_CAG",false};
-	{"F18C_BORT_NUMBER_NOSE_R_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_R_10", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_CAG",false};
-	{"F18C_BORT_NUMBER_NOSE_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_R_01", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_CAG",false};
-	{"F18C_BORT_NUMBER_NOSE_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_R_01", DECAL ,"empty",true};	
-		
-	--Flap Aircraft Numbers (USN)
-	--Left
-	{"F18C_BORT_NUMBER_ZAK_L_100", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_CAG",false};
-	{"F18C_BORT_NUMBER_ZAK_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_ZAK_L_10", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_CAG",false};
-	{"F18C_BORT_NUMBER_ZAK_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_ZAK_L_01", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_CAG",false};
-	{"F18C_BORT_NUMBER_ZAK_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_ZAK_R_100", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_CAG",false};
-	{"F18C_BORT_NUMBER_ZAK_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_ZAK_R_10", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_CAG",false};
-	{"F18C_BORT_NUMBER_ZAK_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_ZAK_R_01", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_CAG",false};
-	{"F18C_BORT_NUMBER_ZAK_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_R_01", DECAL ,"empty",true};
+	--*NEW 2.8.4 Bort Numbers*
+	--USN_MODEX_NOSE
+	{"f18c1_number_nose_left"			, DIFFUSE				, "F18C_1_DIFF_VFA143_PukinDogs_Line", false};
+	{"f18c1_number_nose_left"			, SPECULAR				, "F18C_1_DIF_RoughMet", false};
+	{"f18c1_number_nose_left"			, DECAL					, "empty", true};
+	{"f18c1_number_nose_right"			, DIFFUSE				, "F18C_1_DIFF_VFA143_PukinDogs_Line", false};
+	{"f18c1_number_nose_right"			, SPECULAR				, "F18C_1_DIF_RoughMet", false};
+	{"f18c1_number_nose_right"			, DECAL					, "empty", true};
+	--RAAF /KAF/SWITZ_MODEX_FUSELAGE_FRONT_MID_BACK_GEAR_DOORS_SMALL
+	{"f18c1_number_F"					, DIFFUSE				, "F18C_1_DIFF_VFA143_PukinDogs_Line", false};
+	{"f18c1_number_F"					, SPECULAR				, "F18C_1_DIF_RoughMet", false};
+	{"f18c1_number_F"					, DECAL					, "empty", true};
+	--KAF_MODEX_VERTICAL_STABILIZERS_AND_FLAPS_MODEX
+	{"f18c2_number_X"					, DIFFUSE				, "F18C_2_DIFF_VFA143_PukinDogs_Line", false};
+	{"f18c2_number_X"					, SPECULAR				, "F18C_2_DIF_RoughMet", false};
+	{"f18c2_number_X"					, DECAL					, "empty", true};
+	--USN_MODEX_VERTICAL_STABILIZERS
+	{"f18c2_kil_left"					, DIFFUSE				, "F18C_2_DIFF_VFA143_PukinDogs_Line", false};
+	{"f18c2_kil_left"					, SPECULAR				, "F18C_2_DIF_RoughMet", false};
+	{"f18c2_kil_left"					, DECAL					, "empty", true};
+	{"f18c2_kil_right"					, DIFFUSE				, "F18C_2_DIFF_VFA143_PukinDogs_Line", false};
+	{"f18c2_kil_right"					, SPECULAR				, "F18C_2_DIF_RoughMet", false};
+	{"f18c2_kil_right"					, DECAL					, "empty", true};	
 	
-	--Vertical Stab Aircraft Numbers (USN)
-	--Left
-	{"F18C_BORT_NUMBER_KIL_L_100", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_CAG",false};
-	{"F18C_BORT_NUMBER_KIL_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_L_10", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_CAG",false};
-	{"F18C_BORT_NUMBER_KIL_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_L_01", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_CAG",false};
-	{"F18C_BORT_NUMBER_KIL_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_L_01", DECAL ,"empty",true};	
-	--Right
-	{"F18C_BORT_NUMBER_KIL_R_100", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_CAG",false};
-	{"F18C_BORT_NUMBER_KIL_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_R_10", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_CAG",false};
-	{"F18C_BORT_NUMBER_KIL_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_R_01", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_CAG",false};
-	{"F18C_BORT_NUMBER_KIL_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_R_01", DECAL ,"empty",true};		
-
-	--Nose Aircraft Numbers (KUWAIT)
-	--Left
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_100", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_CAG",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_10", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_CAG",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_01", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_CAG",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_100", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_CAG",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_10", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_CAG",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_01", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_CAG",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_01", DECAL ,"empty",true};		
 	
+	--(0.0 = ON, 1.0 OFF)
 
-	--Vertical Stab Numbers (KUWAIT)
-	--Right
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_100", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_CAG",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_10", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_CAG",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_01", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_CAG",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_100", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_CAG",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_10", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_CAG",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_01", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_CAG",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_01", DECAL ,"empty",true};		
-
-	--Nose Aircraft Numbers (FINLAND)
-	--Left
-	{"F18C_BORT_NUMBER_NOSE_fin_L_10", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_CAG",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_fin_L_01", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_CAG",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_NOSE_fin_R_10", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_CAG",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_fin_R_01", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_CAG",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_01", DECAL ,"empty",true};			
-
-	--Vertical Tail Numbers (SWITZERLAND)
-	--Right
-	{"F18C_BORT_NUMBER_KIL_Switz_R_100", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_CAG",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_10", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_CAG",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Switz_R_01", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_CAG",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_KIL_Switz_L_100", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_CAG",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_10", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_CAG",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Switz_L_01", 0 ,"F18C_2_DIFF_VFA143_PukinDogs_CAG",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_01", DECAL ,"empty",true};
-
-	--Gear Door Numbers (RAAF)
-	--Right
-	{"F18C_BORT_NUMBER_STV_aus_R_10", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_CAG",false};
-	{"F18C_BORT_NUMBER_STV_aus_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_STV_aus_R_01", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_CAG",false};
-	{"F18C_BORT_NUMBER_STV_aus_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_STV_aus_L_10", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_CAG",false};
-	{"F18C_BORT_NUMBER_STV_aus_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_STV_aus_L_01", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_CAG",false};
-	{"F18C_BORT_NUMBER_STV_aus_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_L_01", DECAL ,"empty",true};		
-		
-	--Aft Fuselage Numbers (RAAF)
-	--Right
-	{"F18C_BORT_NUMBER_MTW_aus_R_10", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_CAG",false};
-	{"F18C_BORT_NUMBER_MTW_aus_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_MTW_aus_R_01", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_CAG",false};
-	{"F18C_BORT_NUMBER_MTW_aus_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_MTW_aus_L_10", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_CAG",false};
-	{"F18C_BORT_NUMBER_MTW_aus_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_MTW_aus_L_01", 0 ,"F18C_1_DIFF_VFA143_PukinDogs_CAG",false};
-	{"F18C_BORT_NUMBER_MTW_aus_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_L_01", DECAL ,"empty",true};	
+	
 }
+
+custom_args = {
+	[0027] = 1.0, -- USN_MODEX_VERTICAL_STABILIZERS
+	[1000] = 1.0, -- USN_MODEX_FLAPS
+	[1001] = 1.0, -- USN_MODEX_NOSE
+	[1002] = 1.0, -- KUWAIT_MODEX_NOSE_AND_VERTICAL_STABILIZERS
+	[1003] = 1.0, -- AUSTRAILIA_MODEX_REAR_FUSELAGE_AND_GEAR_DOORS
+	[1004] = 1.0, -- FINLAND_MODEX_FORWARD_FUSELAGE
+	[1005] = 1.0, -- SWITZERLAND_MODEX_VERTICAL_STABILIZERS
+}
+
 name = "VFA-143 Pukin' Dogs - 220 - Apollo - JTF-13 Dep. Commander"
 countries = {"USA", "RUS", "FRA", "UKR", "SPN", "NETH", "TUR", "BEL", "GER", "NOR", "CAN", "DEN", "UK", "GRG", "ISR", "ABH", "RSO"}
 --By SkateZilla Graphics Studios 2018 (07.11.2018)

--- a/FA-18C_hornet/VFA-143 Line/description.lua.bak
+++ b/FA-18C_hornet/VFA-143 Line/description.lua.bak
@@ -12,31 +12,6 @@ livery = {
 	{"pilot_F18_patch", ROUGHNESS_METALLIC ,"../VFA-143Textures/Pilot_F18_Patch_PukinDogs_RoughMet",false};
 	{"pilot_F18_helmet", 0, "../VFA-143Textures/PILOT_F18_HELMET_VFA_DEFAULT", false};
 	
-	--Grey Naval bombs
-	{"GBU_12",	DIFFUSE			,	"gbu_12t_gray_diff", true};
-	{"GBU_12",	NORMAL_MAP			,	"gbu_12_nm", true};
-	{"GBU_12",	ROUGHNESS_METALLIC			,	"gbu_12_diff_roughmet", true};
-	{"MK_82", DIFFUSE, "mk_82t_grey_diff", true};
-	{"MK_82", NORMAL_MAP, "mk_82_nm", true};
-	{"MK_82", ROUGHNESS_METALLIC, "mk_82_diff_roughmet", true};
-	{"mk_83", DIFFUSE, "mk_83tgrey_diff", true};
-	{"mk_83", NORMAL_MAP, "mk_83_nm", true};
-	{"mk_83", ROUGHNESS_METALLIC, "mk_83_diff_roughmet", true};
-	{"GBU_38", DIFFUSE, "gbu_38t_diff", true};
-	{"GBU_38", NORMAL_MAP, "gbu_38_nm", true};
-	{"GBU_38", ROUGHNESS_METALLIC, "gbu_38_diff_roughmet", true};
-	{"GBU_31", DIFFUSE, "gbu_31t_gray_diff", true};
-	{"GBU_31", NORMAL_MAP, "gbu_31_nm", true};
-	{"GBU_31", ROUGHNESS_METALLIC, "gbu_31_diff_roughmet", true};
-	{"mk_84", NORMAL_MAP, "mk_84_nm", true};
-	{"mk_84", ROUGHNESS_METALLIC, "mk_84_diff_roughmet", true};
-	{"GBU_10", DIFFUSE, "gbu_10_diff", true};
-	{"GBU_10", NORMAL_MAP, "gbu_10_nm", true};
-	{"GBU_10", ROUGHNESS_METALLIC, "gbu_10_diff_roughmet", true};
-	{"GBU_16", DIFFUSE, "gbu_16t_gray_diff", true};
-	{"GBU_16", NORMAL_MAP, "gbu_16t_nm", true};
-	{"GBU_16", ROUGHNESS_METALLIC, "gbu_16t_gray_diff_roughmet", true};
-	
 	--Fuel Tanks
 	{"FPU_8A", 0 ,"../VFA-143Textures/FPU_8A_PukinDogs_Line",false};
 	{"FPU_8A", ROUGHNESS_METALLIC ,"FPU_8A_Diff_RoughMet",true};	

--- a/FA-18C_hornet/VMFA-224 - 000 - Line/description.lua
+++ b/FA-18C_hornet/VMFA-224 - 000 - Line/description.lua
@@ -12,6 +12,30 @@ livery = {
 	{"pilot_F18", 0 ,"pilot_F18",false};
 	{"pilot_F18", 2 ,"pilot_F18_roughmet",true};
 	
+	--Grey Naval bombs
+	{"GBU_12",	DIFFUSE			,	"gbu_12t_gray_diff", true};
+	{"GBU_12",	NORMAL_MAP			,	"gbu_12_nm", true};
+	{"GBU_12",	ROUGHNESS_METALLIC			,	"gbu_12_diff_roughmet", true};
+	{"MK_82", DIFFUSE, "mk_82t_grey_diff", true};
+	{"MK_82", NORMAL_MAP, "mk_82_nm", true};
+	{"MK_82", ROUGHNESS_METALLIC, "mk_82_diff_roughmet", true};
+	{"mk_83", DIFFUSE, "mk_83tgrey_diff", true};
+	{"mk_83", NORMAL_MAP, "mk_83_nm", true};
+	{"mk_83", ROUGHNESS_METALLIC, "mk_83_diff_roughmet", true};
+	{"GBU_38", DIFFUSE, "gbu_38t_diff", true};
+	{"GBU_38", NORMAL_MAP, "gbu_38_nm", true};
+	{"GBU_38", ROUGHNESS_METALLIC, "gbu_38_diff_roughmet", true};
+	{"GBU_31", DIFFUSE, "gbu_31t_gray_diff", true};
+	{"GBU_31", NORMAL_MAP, "gbu_31_nm", true};
+	{"GBU_31", ROUGHNESS_METALLIC, "gbu_31_diff_roughmet", true};
+	{"mk_84", NORMAL_MAP, "mk_84_nm", true};
+	{"mk_84", ROUGHNESS_METALLIC, "mk_84_diff_roughmet", true};
+	{"GBU_10", DIFFUSE, "gbu_10_diff", true};
+	{"GBU_10", NORMAL_MAP, "gbu_10_nm", true};
+	{"GBU_10", ROUGHNESS_METALLIC, "gbu_10_diff_roughmet", true};
+	{"GBU_16", DIFFUSE, "gbu_16t_gray_diff", true};
+	{"GBU_16", NORMAL_MAP, "gbu_16t_nm", true};
+	{"GBU_16", ROUGHNESS_METALLIC, "gbu_16t_gray_diff_roughmet", true};
 	
 	--Fuel Tanks
 	{"FPU_8A", 0 ,"FPU_8A1",false};

--- a/FA-18C_hornet/VMFA-224 - 000 - Line/description.lua.bak
+++ b/FA-18C_hornet/VMFA-224 - 000 - Line/description.lua.bak
@@ -17,186 +17,44 @@ livery = {
 	{"FPU_8A", 0 ,"FPU_8A1",false};
 	{"FPU_8A", ROUGHNESS_METALLIC ,"FPU_8A_Diff_RoughMet",true};	
 	
-	--Nose Aircraft Numbers (USN)
-	--Left
-	{"F18C_BORT_NUMBER_NOSE_L_100", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_L_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_L_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_L_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_NOSE_R_100", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_R_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_R_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_R_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_R_01", DECAL ,"empty",true};	
-		
-	--Flap Aircraft Numbers (USN)
-	--Left
-	{"F18C_BORT_NUMBER_ZAK_L_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_ZAK_L_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_ZAK_L_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_ZAK_R_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_ZAK_R_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_ZAK_R_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_R_01", DECAL ,"empty",true};
+	--*NEW 2.8.4 Bort Numbers*
+	--USN_MODEX_NOSE
+	{"f18c1_number_nose_left"			, DIFFUSE				, "F18C_1_DIFF_VMFA_224_Bengals", false};
+	{"f18c1_number_nose_left"			, SPECULAR				, "F18C_1_DIF_RoughMet", false};
+	{"f18c1_number_nose_left"			, DECAL					, "empty", true};
+	{"f18c1_number_nose_right"			, DIFFUSE				, "F18C_1_DIFF_VMFA_224_Bengals", false};
+	{"f18c1_number_nose_right"			, SPECULAR				, "F18C_1_DIF_RoughMet", false};
+	{"f18c1_number_nose_right"			, DECAL					, "empty", true};
+	--RAAF /KAF/SWITZ_MODEX_FUSELAGE_FRONT_MID_BACK_GEAR_DOORS_SMALL
+	{"f18c1_number_F"					, DIFFUSE				, "F18C_1_DIFF_VMFA_224_Bengals", false};
+	{"f18c1_number_F"					, SPECULAR				, "F18C_1_DIF_RoughMet", false};
+	{"f18c1_number_F"					, DECAL					, "empty", true};
+	--KAF_MODEX_VERTICAL_STABILIZERS_AND_FLAPS_MODEX
+	{"f18c2_number_X"					, DIFFUSE				, "F18C_2_DIFF_VMFA_224_Bengals", false};
+	{"f18c2_number_X"					, SPECULAR				, "F18C_2_DIF_RoughMet", false};
+	{"f18c2_number_X"					, DECAL					, "empty", true};
+	--USN_MODEX_VERTICAL_STABILIZERS
+	{"f18c2_kil_left"					, DIFFUSE				, "F18C_2_DIFF_VMFA_224_Bengals", false};
+	{"f18c2_kil_left"					, SPECULAR				, "F18C_2_DIF_RoughMet", false};
+	{"f18c2_kil_left"					, DECAL					, "empty", true};
+	{"f18c2_kil_right"					, DIFFUSE				, "F18C_2_DIFF_VMFA_224_Bengals", false};
+	{"f18c2_kil_right"					, SPECULAR				, "F18C_2_DIF_RoughMet", false};
+	{"f18c2_kil_right"					, DECAL					, "empty", true};	
 	
-	--Vertical Stab Aircraft Numbers (USN)
-	--Left
-	{"F18C_BORT_NUMBER_KIL_L_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_L_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_L_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_L_01", DECAL ,"empty",true};	
-	--Right
-	{"F18C_BORT_NUMBER_KIL_R_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_R_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_R_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_R_01", DECAL ,"empty",true};		
-
-	--Nose Aircraft Numbers (KUWAIT)
-	--Left
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_100", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_100", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_01", DECAL ,"empty",true};		
 	
+	--(0.0 = ON, 1.0 OFF)
 
-	--Vertical Stab Numbers (KUWAIT)
-	--Right
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_01", DECAL ,"empty",true};		
+	
+}
 
-	--Nose Aircraft Numbers (FINLAND)
-	--Left
-	{"F18C_BORT_NUMBER_NOSE_fin_L_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_fin_L_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_NOSE_fin_R_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_fin_R_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_01", DECAL ,"empty",true};			
-
-	--Vertical Tail Numbers (SWITZERLAND)
-	--Right
-	{"F18C_BORT_NUMBER_KIL_Switz_R_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Switz_R_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_KIL_Switz_L_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Switz_L_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_01", DECAL ,"empty",true};
-
-	--Gear Door Numbers (RAAF)
-	--Right
-	{"F18C_BORT_NUMBER_STV_aus_R_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_STV_aus_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_STV_aus_R_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_STV_aus_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_STV_aus_L_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_STV_aus_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_STV_aus_L_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_STV_aus_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_L_01", DECAL ,"empty",true};		
-		
-	--Aft Fuselage Numbers (RAAF)
-	--Right
-	{"F18C_BORT_NUMBER_MTW_aus_R_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_MTW_aus_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_MTW_aus_R_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_MTW_aus_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_MTW_aus_L_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_MTW_aus_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_MTW_aus_L_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_MTW_aus_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_L_01", DECAL ,"empty",true};		
+custom_args = {
+	[0027] = 0.0, -- USN_MODEX_VERTICAL_STABILIZERS
+	[1000] = 0.0, -- USN_MODEX_FLAPS
+	[1001] = 0.0, -- USN_MODEX_NOSE
+	[1002] = 1.0, -- KUWAIT_MODEX_NOSE_AND_VERTICAL_STABILIZERS
+	[1003] = 1.0, -- AUSTRAILIA_MODEX_REAR_FUSELAGE_AND_GEAR_DOORS
+	[1004] = 1.0, -- FINLAND_MODEX_FORWARD_FUSELAGE
+	[1005] = 1.0, -- SWITZERLAND_MODEX_VERTICAL_STABILIZERS
 }
 name = "VMFA(AW)-224 Fighting Bengals Line"
 

--- a/FA-18C_hornet/VMFA-224 - 400 - CAG, DCAG STRIPES/description.lua
+++ b/FA-18C_hornet/VMFA-224 - 400 - CAG, DCAG STRIPES/description.lua
@@ -12,6 +12,30 @@ livery = {
 	{"pilot_F18", 0 ,"../VMFA-224 - 000 - Line/pilot_F18",false};
 	{"pilot_F18", 2 ,"pilot_F18_roughmet",true};
 	
+	--Grey Naval bombs
+	{"GBU_12",	DIFFUSE			,	"gbu_12t_gray_diff", true};
+	{"GBU_12",	NORMAL_MAP			,	"gbu_12_nm", true};
+	{"GBU_12",	ROUGHNESS_METALLIC			,	"gbu_12_diff_roughmet", true};
+	{"MK_82", DIFFUSE, "mk_82t_grey_diff", true};
+	{"MK_82", NORMAL_MAP, "mk_82_nm", true};
+	{"MK_82", ROUGHNESS_METALLIC, "mk_82_diff_roughmet", true};
+	{"mk_83", DIFFUSE, "mk_83tgrey_diff", true};
+	{"mk_83", NORMAL_MAP, "mk_83_nm", true};
+	{"mk_83", ROUGHNESS_METALLIC, "mk_83_diff_roughmet", true};
+	{"GBU_38", DIFFUSE, "gbu_38t_diff", true};
+	{"GBU_38", NORMAL_MAP, "gbu_38_nm", true};
+	{"GBU_38", ROUGHNESS_METALLIC, "gbu_38_diff_roughmet", true};
+	{"GBU_31", DIFFUSE, "gbu_31t_gray_diff", true};
+	{"GBU_31", NORMAL_MAP, "gbu_31_nm", true};
+	{"GBU_31", ROUGHNESS_METALLIC, "gbu_31_diff_roughmet", true};
+	{"mk_84", NORMAL_MAP, "mk_84_nm", true};
+	{"mk_84", ROUGHNESS_METALLIC, "mk_84_diff_roughmet", true};
+	{"GBU_10", DIFFUSE, "gbu_10_diff", true};
+	{"GBU_10", NORMAL_MAP, "gbu_10_nm", true};
+	{"GBU_10", ROUGHNESS_METALLIC, "gbu_10_diff_roughmet", true};
+	{"GBU_16", DIFFUSE, "gbu_16t_gray_diff", true};
+	{"GBU_16", NORMAL_MAP, "gbu_16t_nm", true};
+	{"GBU_16", ROUGHNESS_METALLIC, "gbu_16t_gray_diff_roughmet", true};
 	
 	--Fuel Tanks
 	{"FPU_8A", 0 ,"FPU_8A",false};

--- a/FA-18C_hornet/VMFA-224 - 400 - CAG, DCAG STRIPES/description.lua.bak
+++ b/FA-18C_hornet/VMFA-224 - 400 - CAG, DCAG STRIPES/description.lua.bak
@@ -1,10 +1,10 @@
 livery = {
 	--Main Maps
 	{"f18c1", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"f18c1", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
+	{"f18c1", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",false};
 
 	{"f18c2", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"f18c2", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
+	{"f18c2", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",false};
 	
 	--Pilot Maps
 	{"pilot_F18_helmet", 0, "pilot_F18_helmet_VMFAAW224_bengal", false};
@@ -14,8 +14,8 @@ livery = {
 	
 	
 	--Fuel Tanks
-	{"FPU_8A", 0 ,"FPU_8A2",false};
-	{"FPU_8A", ROUGHNESS_METALLIC ,"FPU_8A_Diff_RoughMet",true};	
+	{"FPU_8A", 0 ,"FPU_8A",false};
+	{"FPU_8A", ROUGHNESS_METALLIC ,"FPU_8A_DIFF_RoughMet",false};	
 	
 	--*NEW 2.8.4 Bort Numbers*
 	--USN_MODEX_NOSE
@@ -56,5 +56,5 @@ custom_args = {
 	[1004] = 1.0, -- FINLAND_MODEX_FORWARD_FUSELAGE
 	[1005] = 1.0, -- SWITZERLAND_MODEX_VERTICAL_STABILIZERS
 }
-name = "VMFA(AW)-224 Fighting Bengals - 400 - CAG BLUE STRIPES"
+name = "VMFA(AW)-224 Fighting Bengals - 400 - CAG / DCAG STRIPES"
 

--- a/FA-18C_hornet/VMFA-224 - 400 - Void CAG HIVIZ/description.lua
+++ b/FA-18C_hornet/VMFA-224 - 400 - Void CAG HIVIZ/description.lua
@@ -12,6 +12,30 @@ livery = {
 	{"pilot_F18", 0 ,"../VMFA-224 - 000 - Line/pilot_F18",false};
 	{"pilot_F18", 2 ,"pilot_F18_roughmet",true};
 	
+	--Grey Naval bombs
+	{"GBU_12",	DIFFUSE			,	"gbu_12t_gray_diff", true};
+	{"GBU_12",	NORMAL_MAP			,	"gbu_12_nm", true};
+	{"GBU_12",	ROUGHNESS_METALLIC			,	"gbu_12_diff_roughmet", true};
+	{"MK_82", DIFFUSE, "mk_82t_grey_diff", true};
+	{"MK_82", NORMAL_MAP, "mk_82_nm", true};
+	{"MK_82", ROUGHNESS_METALLIC, "mk_82_diff_roughmet", true};
+	{"mk_83", DIFFUSE, "mk_83tgrey_diff", true};
+	{"mk_83", NORMAL_MAP, "mk_83_nm", true};
+	{"mk_83", ROUGHNESS_METALLIC, "mk_83_diff_roughmet", true};
+	{"GBU_38", DIFFUSE, "gbu_38t_diff", true};
+	{"GBU_38", NORMAL_MAP, "gbu_38_nm", true};
+	{"GBU_38", ROUGHNESS_METALLIC, "gbu_38_diff_roughmet", true};
+	{"GBU_31", DIFFUSE, "gbu_31t_gray_diff", true};
+	{"GBU_31", NORMAL_MAP, "gbu_31_nm", true};
+	{"GBU_31", ROUGHNESS_METALLIC, "gbu_31_diff_roughmet", true};
+	{"mk_84", NORMAL_MAP, "mk_84_nm", true};
+	{"mk_84", ROUGHNESS_METALLIC, "mk_84_diff_roughmet", true};
+	{"GBU_10", DIFFUSE, "gbu_10_diff", true};
+	{"GBU_10", NORMAL_MAP, "gbu_10_nm", true};
+	{"GBU_10", ROUGHNESS_METALLIC, "gbu_10_diff_roughmet", true};
+	{"GBU_16", DIFFUSE, "gbu_16t_gray_diff", true};
+	{"GBU_16", NORMAL_MAP, "gbu_16t_nm", true};
+	{"GBU_16", ROUGHNESS_METALLIC, "gbu_16t_gray_diff_roughmet", true};
 	
 	--Fuel Tanks
 	{"FPU_8A", 0 ,"FPU_8A2",false};

--- a/FA-18C_hornet/VMFA-224 - 400 - Void CAG HIVIZ/description.lua.bak
+++ b/FA-18C_hornet/VMFA-224 - 400 - Void CAG HIVIZ/description.lua.bak
@@ -17,186 +17,45 @@ livery = {
 	{"FPU_8A", 0 ,"FPU_8A2",false};
 	{"FPU_8A", ROUGHNESS_METALLIC ,"FPU_8A_Diff_RoughMet",true};	
 	
-	--Nose Aircraft Numbers (USN)
-	--Left
-	{"F18C_BORT_NUMBER_NOSE_L_100", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_L_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_L_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_L_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_NOSE_R_100", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_R_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_R_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_R_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_R_01", DECAL ,"empty",true};	
-		
-	--Flap Aircraft Numbers (USN)
-	--Left
-	{"F18C_BORT_NUMBER_ZAK_L_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_ZAK_L_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_ZAK_L_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_ZAK_R_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_ZAK_R_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_ZAK_R_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_R_01", DECAL ,"empty",true};
+	--*NEW 2.8.4 Bort Numbers*
+	--USN_MODEX_NOSE
+	{"f18c1_number_nose_left"			, DIFFUSE				, "F18C_1_DIFF_VMFA_224_Bengals", false};
+	{"f18c1_number_nose_left"			, SPECULAR				, "F18C_1_DIF_RoughMet", false};
+	{"f18c1_number_nose_left"			, DECAL					, "empty", true};
+	{"f18c1_number_nose_right"			, DIFFUSE				, "F18C_1_DIFF_VMFA_224_Bengals", false};
+	{"f18c1_number_nose_right"			, SPECULAR				, "F18C_1_DIF_RoughMet", false};
+	{"f18c1_number_nose_right"			, DECAL					, "empty", true};
+	--RAAF /KAF/SWITZ_MODEX_FUSELAGE_FRONT_MID_BACK_GEAR_DOORS_SMALL
+	{"f18c1_number_F"					, DIFFUSE				, "F18C_1_DIFF_VMFA_224_Bengals", false};
+	{"f18c1_number_F"					, SPECULAR				, "F18C_1_DIF_RoughMet", false};
+	{"f18c1_number_F"					, DECAL					, "empty", true};
+	--KAF_MODEX_VERTICAL_STABILIZERS_AND_FLAPS_MODEX
+	{"f18c2_number_X"					, DIFFUSE				, "F18C_2_DIFF_VMFA_224_Bengals", false};
+	{"f18c2_number_X"					, SPECULAR				, "F18C_2_DIF_RoughMet", false};
+	{"f18c2_number_X"					, DECAL					, "empty", true};
+	--USN_MODEX_VERTICAL_STABILIZERS
+	{"f18c2_kil_left"					, DIFFUSE				, "F18C_2_DIFF_VMFA_224_Bengals", false};
+	{"f18c2_kil_left"					, SPECULAR				, "F18C_2_DIF_RoughMet", false};
+	{"f18c2_kil_left"					, DECAL					, "empty", true};
+	{"f18c2_kil_right"					, DIFFUSE				, "F18C_2_DIFF_VMFA_224_Bengals", false};
+	{"f18c2_kil_right"					, SPECULAR				, "F18C_2_DIF_RoughMet", false};
+	{"f18c2_kil_right"					, DECAL					, "empty", true};	
 	
-	--Vertical Stab Aircraft Numbers (USN)
-	--Left
-	{"F18C_BORT_NUMBER_KIL_L_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_L_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_L_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_L_01", DECAL ,"empty",true};	
-	--Right
-	{"F18C_BORT_NUMBER_KIL_R_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_R_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_R_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_R_01", DECAL ,"empty",true};		
-
-	--Nose Aircraft Numbers (KUWAIT)
-	--Left
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_100", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_100", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_01", DECAL ,"empty",true};		
 	
+	--(0.0 = ON, 1.0 OFF)
 
-	--Vertical Stab Numbers (KUWAIT)
-	--Right
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_01", DECAL ,"empty",true};		
-
-	--Nose Aircraft Numbers (FINLAND)
-	--Left
-	{"F18C_BORT_NUMBER_NOSE_fin_L_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_fin_L_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_NOSE_fin_R_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_fin_R_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_01", DECAL ,"empty",true};			
-
-	--Vertical Tail Numbers (SWITZERLAND)
-	--Right
-	{"F18C_BORT_NUMBER_KIL_Switz_R_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Switz_R_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_KIL_Switz_L_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Switz_L_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_01", DECAL ,"empty",true};
-
-	--Gear Door Numbers (RAAF)
-	--Right
-	{"F18C_BORT_NUMBER_STV_aus_R_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_STV_aus_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_STV_aus_R_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_STV_aus_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_STV_aus_L_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_STV_aus_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_STV_aus_L_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_STV_aus_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_L_01", DECAL ,"empty",true};		
-		
-	--Aft Fuselage Numbers (RAAF)
-	--Right
-	{"F18C_BORT_NUMBER_MTW_aus_R_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_MTW_aus_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_MTW_aus_R_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_MTW_aus_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_MTW_aus_L_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_MTW_aus_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_MTW_aus_L_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_MTW_aus_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_L_01", DECAL ,"empty",true};		
+	
 }
+
+custom_args = {
+	[0027] = 1.0, -- USN_MODEX_VERTICAL_STABILIZERS
+	[1000] = 1.0, -- USN_MODEX_FLAPS
+	[1001] = 1.0, -- USN_MODEX_NOSE
+	[1002] = 1.0, -- KUWAIT_MODEX_NOSE_AND_VERTICAL_STABILIZERS
+	[1003] = 1.0, -- AUSTRAILIA_MODEX_REAR_FUSELAGE_AND_GEAR_DOORS
+	[1004] = 1.0, -- FINLAND_MODEX_FORWARD_FUSELAGE
+	[1005] = 1.0, -- SWITZERLAND_MODEX_VERTICAL_STABILIZERS
+}
+
 name = "VMFA(AW)-224 Fighting Bengals - 400 - Void - CAG HiViz"
 

--- a/FA-18C_hornet/VMFA-224 - 401 - Pocket CO HIVIZ/description.lua
+++ b/FA-18C_hornet/VMFA-224 - 401 - Pocket CO HIVIZ/description.lua
@@ -12,6 +12,30 @@ livery = {
 	{"pilot_F18", 0 ,"../VMFA-224 - 000 - Line/pilot_F18",false};
 	{"pilot_F18", 2 ,"pilot_F18_roughmet",true};
 	
+	--Grey Naval bombs
+	{"GBU_12",	DIFFUSE			,	"gbu_12t_gray_diff", true};
+	{"GBU_12",	NORMAL_MAP			,	"gbu_12_nm", true};
+	{"GBU_12",	ROUGHNESS_METALLIC			,	"gbu_12_diff_roughmet", true};
+	{"MK_82", DIFFUSE, "mk_82t_grey_diff", true};
+	{"MK_82", NORMAL_MAP, "mk_82_nm", true};
+	{"MK_82", ROUGHNESS_METALLIC, "mk_82_diff_roughmet", true};
+	{"mk_83", DIFFUSE, "mk_83tgrey_diff", true};
+	{"mk_83", NORMAL_MAP, "mk_83_nm", true};
+	{"mk_83", ROUGHNESS_METALLIC, "mk_83_diff_roughmet", true};
+	{"GBU_38", DIFFUSE, "gbu_38t_diff", true};
+	{"GBU_38", NORMAL_MAP, "gbu_38_nm", true};
+	{"GBU_38", ROUGHNESS_METALLIC, "gbu_38_diff_roughmet", true};
+	{"GBU_31", DIFFUSE, "gbu_31t_gray_diff", true};
+	{"GBU_31", NORMAL_MAP, "gbu_31_nm", true};
+	{"GBU_31", ROUGHNESS_METALLIC, "gbu_31_diff_roughmet", true};
+	{"mk_84", NORMAL_MAP, "mk_84_nm", true};
+	{"mk_84", ROUGHNESS_METALLIC, "mk_84_diff_roughmet", true};
+	{"GBU_10", DIFFUSE, "gbu_10_diff", true};
+	{"GBU_10", NORMAL_MAP, "gbu_10_nm", true};
+	{"GBU_10", ROUGHNESS_METALLIC, "gbu_10_diff_roughmet", true};
+	{"GBU_16", DIFFUSE, "gbu_16t_gray_diff", true};
+	{"GBU_16", NORMAL_MAP, "gbu_16t_nm", true};
+	{"GBU_16", ROUGHNESS_METALLIC, "gbu_16t_gray_diff_roughmet", true};
 	
 	--Fuel Tanks
 	{"FPU_8A", 0 ,"FPU_8A2",false};

--- a/FA-18C_hornet/VMFA-224 - 401 - Pocket CO HIVIZ/description.lua.bak
+++ b/FA-18C_hornet/VMFA-224 - 401 - Pocket CO HIVIZ/description.lua.bak
@@ -12,7 +12,30 @@ livery = {
 	{"pilot_F18", 0 ,"../VMFA-224 - 000 - Line/pilot_F18",false};
 	{"pilot_F18", 2 ,"pilot_F18_roughmet",true};
 	
-	
+	--Grey Naval bombs
+	{"GBU_12",	DIFFUSE			,	"gbu_12t_gray_diff", true};
+	{"GBU_12",	NORMAL_MAP			,	"gbu_12_nm", true};
+	{"GBU_12",	ROUGHNESS_METALLIC			,	"gbu_12_diff_roughmet", true};
+	{"MK_82", DIFFUSE, "mk_82t_grey_diff", true};
+	{"MK_82", NORMAL_MAP, "mk_82_nm", true};
+	{"MK_82", ROUGHNESS_METALLIC, "mk_82_diff_roughmet", true};
+	{"mk_83", DIFFUSE, "mk_83tgrey_diff", true};
+	{"mk_83", NORMAL_MAP, "mk_83_nm", true};
+	{"mk_83", ROUGHNESS_METALLIC, "mk_83_diff_roughmet", true};
+	{"GBU_38", DIFFUSE, "gbu_38t_diff", true};
+	{"GBU_38", NORMAL_MAP, "gbu_38_nm", true};
+	{"GBU_38", ROUGHNESS_METALLIC, "gbu_38_diff_roughmet", true};
+	{"GBU_31", DIFFUSE, "gbu_31t_gray_diff", true};
+	{"GBU_31", NORMAL_MAP, "gbu_31_nm", true};
+	{"GBU_31", ROUGHNESS_METALLIC, "gbu_31_diff_roughmet", true};
+	{"mk_84", NORMAL_MAP, "mk_84_nm", true};
+	{"mk_84", ROUGHNESS_METALLIC, "mk_84_diff_roughmet", true};
+	{"GBU_10", DIFFUSE, "gbu_10_diff", true};
+	{"GBU_10", NORMAL_MAP, "gbu_10_nm", true};
+	{"GBU_10", ROUGHNESS_METALLIC, "gbu_10_diff_roughmet", true};
+	{"GBU_16", DIFFUSE, "gbu_16t_gray_diff", true};
+	{"GBU_16", NORMAL_MAP, "gbu_16t_nm", true};
+	{"GBU_16", ROUGHNESS_METALLIC, "gbu_16t_gray_diff_roughmet", true};
 	--Fuel Tanks
 	{"FPU_8A", 0 ,"FPU_8A2",false};
 	{"FPU_8A", ROUGHNESS_METALLIC ,"FPU_8A_Diff_RoughMet",true};	
@@ -44,6 +67,10 @@ livery = {
 	
 	
 	--(0.0 = ON, 1.0 OFF)
+
+	
+}
+
 custom_args = {
 	[0027] = 1.0, -- USN_MODEX_VERTICAL_STABILIZERS
 	[1000] = 1.0, -- USN_MODEX_FLAPS
@@ -53,7 +80,6 @@ custom_args = {
 	[1004] = 1.0, -- FINLAND_MODEX_FORWARD_FUSELAGE
 	[1005] = 1.0, -- SWITZERLAND_MODEX_VERTICAL_STABILIZERS
 }
-	
-}
+
 name = "VMFA(AW)-224 Fighting Bengals - 401 - Pocket - CO HiViz"
 

--- a/FA-18C_hornet/VMFA-224 - 401 - Pocket CO STRIPES/description.lua
+++ b/FA-18C_hornet/VMFA-224 - 401 - Pocket CO STRIPES/description.lua
@@ -12,6 +12,30 @@ livery = {
 	{"pilot_F18", 0 ,"../VMFA-224 - 000 - Line/pilot_F18",false};
 	{"pilot_F18", 2 ,"pilot_F18_roughmet",true};
 	
+	--Grey Naval bombs
+	{"GBU_12",	DIFFUSE			,	"gbu_12t_gray_diff", true};
+	{"GBU_12",	NORMAL_MAP			,	"gbu_12_nm", true};
+	{"GBU_12",	ROUGHNESS_METALLIC			,	"gbu_12_diff_roughmet", true};
+	{"MK_82", DIFFUSE, "mk_82t_grey_diff", true};
+	{"MK_82", NORMAL_MAP, "mk_82_nm", true};
+	{"MK_82", ROUGHNESS_METALLIC, "mk_82_diff_roughmet", true};
+	{"mk_83", DIFFUSE, "mk_83tgrey_diff", true};
+	{"mk_83", NORMAL_MAP, "mk_83_nm", true};
+	{"mk_83", ROUGHNESS_METALLIC, "mk_83_diff_roughmet", true};
+	{"GBU_38", DIFFUSE, "gbu_38t_diff", true};
+	{"GBU_38", NORMAL_MAP, "gbu_38_nm", true};
+	{"GBU_38", ROUGHNESS_METALLIC, "gbu_38_diff_roughmet", true};
+	{"GBU_31", DIFFUSE, "gbu_31t_gray_diff", true};
+	{"GBU_31", NORMAL_MAP, "gbu_31_nm", true};
+	{"GBU_31", ROUGHNESS_METALLIC, "gbu_31_diff_roughmet", true};
+	{"mk_84", NORMAL_MAP, "mk_84_nm", true};
+	{"mk_84", ROUGHNESS_METALLIC, "mk_84_diff_roughmet", true};
+	{"GBU_10", DIFFUSE, "gbu_10_diff", true};
+	{"GBU_10", NORMAL_MAP, "gbu_10_nm", true};
+	{"GBU_10", ROUGHNESS_METALLIC, "gbu_10_diff_roughmet", true};
+	{"GBU_16", DIFFUSE, "gbu_16t_gray_diff", true};
+	{"GBU_16", NORMAL_MAP, "gbu_16t_nm", true};
+	{"GBU_16", ROUGHNESS_METALLIC, "gbu_16t_gray_diff_roughmet", true};
 	
 	--Fuel Tanks
 	{"FPU_8A", 0 ,"FPU_8A",false};

--- a/FA-18C_hornet/VMFA-224 - 401 - Pocket CO STRIPES/description.lua.bak
+++ b/FA-18C_hornet/VMFA-224 - 401 - Pocket CO STRIPES/description.lua.bak
@@ -56,6 +56,5 @@ custom_args = {
 	[1004] = 1.0, -- FINLAND_MODEX_FORWARD_FUSELAGE
 	[1005] = 1.0, -- SWITZERLAND_MODEX_VERTICAL_STABILIZERS
 }
-name = "VMFA(AW)-224 Fighting Bengals - 401 - Pocket - CO Stripes
-"
+name = "VMFA(AW)-224 Fighting Bengals - 401 - Pocket - CO Stripes"
 

--- a/FA-18C_hornet/VMFA-224 - 402 - Deathakiss XO HIVIZ/description.lua
+++ b/FA-18C_hornet/VMFA-224 - 402 - Deathakiss XO HIVIZ/description.lua
@@ -12,6 +12,30 @@ livery = {
 	{"pilot_F18", 0 ,"../VMFA-224 - 000 - Line/pilot_F18",false};
 	{"pilot_F18", 2 ,"pilot_F18_roughmet",true};
 	
+	--Grey Naval bombs
+	{"GBU_12",	DIFFUSE			,	"gbu_12t_gray_diff", true};
+	{"GBU_12",	NORMAL_MAP			,	"gbu_12_nm", true};
+	{"GBU_12",	ROUGHNESS_METALLIC			,	"gbu_12_diff_roughmet", true};
+	{"MK_82", DIFFUSE, "mk_82t_grey_diff", true};
+	{"MK_82", NORMAL_MAP, "mk_82_nm", true};
+	{"MK_82", ROUGHNESS_METALLIC, "mk_82_diff_roughmet", true};
+	{"mk_83", DIFFUSE, "mk_83tgrey_diff", true};
+	{"mk_83", NORMAL_MAP, "mk_83_nm", true};
+	{"mk_83", ROUGHNESS_METALLIC, "mk_83_diff_roughmet", true};
+	{"GBU_38", DIFFUSE, "gbu_38t_diff", true};
+	{"GBU_38", NORMAL_MAP, "gbu_38_nm", true};
+	{"GBU_38", ROUGHNESS_METALLIC, "gbu_38_diff_roughmet", true};
+	{"GBU_31", DIFFUSE, "gbu_31t_gray_diff", true};
+	{"GBU_31", NORMAL_MAP, "gbu_31_nm", true};
+	{"GBU_31", ROUGHNESS_METALLIC, "gbu_31_diff_roughmet", true};
+	{"mk_84", NORMAL_MAP, "mk_84_nm", true};
+	{"mk_84", ROUGHNESS_METALLIC, "mk_84_diff_roughmet", true};
+	{"GBU_10", DIFFUSE, "gbu_10_diff", true};
+	{"GBU_10", NORMAL_MAP, "gbu_10_nm", true};
+	{"GBU_10", ROUGHNESS_METALLIC, "gbu_10_diff_roughmet", true};
+	{"GBU_16", DIFFUSE, "gbu_16t_gray_diff", true};
+	{"GBU_16", NORMAL_MAP, "gbu_16t_nm", true};
+	{"GBU_16", ROUGHNESS_METALLIC, "gbu_16t_gray_diff_roughmet", true};
 	
 	--Fuel Tanks
 	{"FPU_8A", 0 ,"../VMFA-224 - 000 - Line/FPU_8A2",false};

--- a/FA-18C_hornet/VMFA-224 - 402 - Deathakiss XO HIVIZ/description.lua.bak
+++ b/FA-18C_hornet/VMFA-224 - 402 - Deathakiss XO HIVIZ/description.lua.bak
@@ -17,186 +17,45 @@ livery = {
 	{"FPU_8A", 0 ,"../VMFA-224 - 000 - Line/FPU_8A2",false};
 	{"FPU_8A", ROUGHNESS_METALLIC ,"FPU_8A_Diff_RoughMet",true};	
 	
-	--Nose Aircraft Numbers (USN)
-	--Left
-	{"F18C_BORT_NUMBER_NOSE_L_100", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_L_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_L_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_L_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_NOSE_R_100", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_R_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_R_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_R_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_R_01", DECAL ,"empty",true};	
-		
-	--Flap Aircraft Numbers (USN)
-	--Left
-	{"F18C_BORT_NUMBER_ZAK_L_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_ZAK_L_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_ZAK_L_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_ZAK_R_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_ZAK_R_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_ZAK_R_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_R_01", DECAL ,"empty",true};
+	--*NEW 2.8.4 Bort Numbers*
+	--USN_MODEX_NOSE
+	{"f18c1_number_nose_left"			, DIFFUSE				, "F18C_1_DIFF_VMFA_224_Bengals", false};
+	{"f18c1_number_nose_left"			, SPECULAR				, "F18C_1_DIF_RoughMet", false};
+	{"f18c1_number_nose_left"			, DECAL					, "empty", true};
+	{"f18c1_number_nose_right"			, DIFFUSE				, "F18C_1_DIFF_VMFA_224_Bengals", false};
+	{"f18c1_number_nose_right"			, SPECULAR				, "F18C_1_DIF_RoughMet", false};
+	{"f18c1_number_nose_right"			, DECAL					, "empty", true};
+	--RAAF /KAF/SWITZ_MODEX_FUSELAGE_FRONT_MID_BACK_GEAR_DOORS_SMALL
+	{"f18c1_number_F"					, DIFFUSE				, "F18C_1_DIFF_VMFA_224_Bengals", false};
+	{"f18c1_number_F"					, SPECULAR				, "F18C_1_DIF_RoughMet", false};
+	{"f18c1_number_F"					, DECAL					, "empty", true};
+	--KAF_MODEX_VERTICAL_STABILIZERS_AND_FLAPS_MODEX
+	{"f18c2_number_X"					, DIFFUSE				, "F18C_2_DIFF_VMFA_224_Bengals", false};
+	{"f18c2_number_X"					, SPECULAR				, "F18C_2_DIF_RoughMet", false};
+	{"f18c2_number_X"					, DECAL					, "empty", true};
+	--USN_MODEX_VERTICAL_STABILIZERS
+	{"f18c2_kil_left"					, DIFFUSE				, "F18C_2_DIFF_VMFA_224_Bengals", false};
+	{"f18c2_kil_left"					, SPECULAR				, "F18C_2_DIF_RoughMet", false};
+	{"f18c2_kil_left"					, DECAL					, "empty", true};
+	{"f18c2_kil_right"					, DIFFUSE				, "F18C_2_DIFF_VMFA_224_Bengals", false};
+	{"f18c2_kil_right"					, SPECULAR				, "F18C_2_DIF_RoughMet", false};
+	{"f18c2_kil_right"					, DECAL					, "empty", true};	
 	
-	--Vertical Stab Aircraft Numbers (USN)
-	--Left
-	{"F18C_BORT_NUMBER_KIL_L_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_L_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_L_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_L_01", DECAL ,"empty",true};	
-	--Right
-	{"F18C_BORT_NUMBER_KIL_R_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_R_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_R_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_R_01", DECAL ,"empty",true};		
-
-	--Nose Aircraft Numbers (KUWAIT)
-	--Left
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_100", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_100", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_01", DECAL ,"empty",true};		
 	
+	--(0.0 = ON, 1.0 OFF)
 
-	--Vertical Stab Numbers (KUWAIT)
-	--Right
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_01", DECAL ,"empty",true};		
-
-	--Nose Aircraft Numbers (FINLAND)
-	--Left
-	{"F18C_BORT_NUMBER_NOSE_fin_L_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_fin_L_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_NOSE_fin_R_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_fin_R_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_01", DECAL ,"empty",true};			
-
-	--Vertical Tail Numbers (SWITZERLAND)
-	--Right
-	{"F18C_BORT_NUMBER_KIL_Switz_R_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Switz_R_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_KIL_Switz_L_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Switz_L_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_01", DECAL ,"empty",true};
-
-	--Gear Door Numbers (RAAF)
-	--Right
-	{"F18C_BORT_NUMBER_STV_aus_R_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_STV_aus_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_STV_aus_R_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_STV_aus_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_STV_aus_L_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_STV_aus_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_STV_aus_L_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_STV_aus_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_L_01", DECAL ,"empty",true};		
-		
-	--Aft Fuselage Numbers (RAAF)
-	--Right
-	{"F18C_BORT_NUMBER_MTW_aus_R_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_MTW_aus_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_MTW_aus_R_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_MTW_aus_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_MTW_aus_L_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_MTW_aus_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_MTW_aus_L_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_MTW_aus_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_L_01", DECAL ,"empty",true};		
+	
 }
+
+custom_args = {
+	[0027] = 1.0, -- USN_MODEX_VERTICAL_STABILIZERS
+	[1000] = 1.0, -- USN_MODEX_FLAPS
+	[1001] = 1.0, -- USN_MODEX_NOSE
+	[1002] = 1.0, -- KUWAIT_MODEX_NOSE_AND_VERTICAL_STABILIZERS
+	[1003] = 1.0, -- AUSTRAILIA_MODEX_REAR_FUSELAGE_AND_GEAR_DOORS
+	[1004] = 1.0, -- FINLAND_MODEX_FORWARD_FUSELAGE
+	[1005] = 1.0, -- SWITZERLAND_MODEX_VERTICAL_STABILIZERS
+}
+
 name = "VMFA(AW)-224 Fighting Bengals - 402 - Deathakiss - XO HiViz"
 

--- a/FA-18C_hornet/VMFA-224 - 403 - Astro OPSO HIVIZ/description.lua
+++ b/FA-18C_hornet/VMFA-224 - 403 - Astro OPSO HIVIZ/description.lua
@@ -12,6 +12,30 @@ livery = {
 	{"pilot_F18", 0 ,"../VMFA-224 - 000 - Line/pilot_F18",false};
 	{"pilot_F18", 2 ,"pilot_F18_roughmet",true};
 	
+	--Grey Naval bombs
+	{"GBU_12",	DIFFUSE			,	"gbu_12t_gray_diff", true};
+	{"GBU_12",	NORMAL_MAP			,	"gbu_12_nm", true};
+	{"GBU_12",	ROUGHNESS_METALLIC			,	"gbu_12_diff_roughmet", true};
+	{"MK_82", DIFFUSE, "mk_82t_grey_diff", true};
+	{"MK_82", NORMAL_MAP, "mk_82_nm", true};
+	{"MK_82", ROUGHNESS_METALLIC, "mk_82_diff_roughmet", true};
+	{"mk_83", DIFFUSE, "mk_83tgrey_diff", true};
+	{"mk_83", NORMAL_MAP, "mk_83_nm", true};
+	{"mk_83", ROUGHNESS_METALLIC, "mk_83_diff_roughmet", true};
+	{"GBU_38", DIFFUSE, "gbu_38t_diff", true};
+	{"GBU_38", NORMAL_MAP, "gbu_38_nm", true};
+	{"GBU_38", ROUGHNESS_METALLIC, "gbu_38_diff_roughmet", true};
+	{"GBU_31", DIFFUSE, "gbu_31t_gray_diff", true};
+	{"GBU_31", NORMAL_MAP, "gbu_31_nm", true};
+	{"GBU_31", ROUGHNESS_METALLIC, "gbu_31_diff_roughmet", true};
+	{"mk_84", NORMAL_MAP, "mk_84_nm", true};
+	{"mk_84", ROUGHNESS_METALLIC, "mk_84_diff_roughmet", true};
+	{"GBU_10", DIFFUSE, "gbu_10_diff", true};
+	{"GBU_10", NORMAL_MAP, "gbu_10_nm", true};
+	{"GBU_10", ROUGHNESS_METALLIC, "gbu_10_diff_roughmet", true};
+	{"GBU_16", DIFFUSE, "gbu_16t_gray_diff", true};
+	{"GBU_16", NORMAL_MAP, "gbu_16t_nm", true};
+	{"GBU_16", ROUGHNESS_METALLIC, "gbu_16t_gray_diff_roughmet", true};
 	
 	--Fuel Tanks
 	{"FPU_8A", 0 ,"../VMFA-224 - 000 - Line/FPU_8A2",false};

--- a/FA-18C_hornet/VMFA-224 - 403 - Astro OPSO HIVIZ/description.lua.bak
+++ b/FA-18C_hornet/VMFA-224 - 403 - Astro OPSO HIVIZ/description.lua.bak
@@ -17,186 +17,45 @@ livery = {
 	{"FPU_8A", 0 ,"../VMFA-224 - 000 - Line/FPU_8A2",false};
 	{"FPU_8A", ROUGHNESS_METALLIC ,"FPU_8A_Diff_RoughMet",true};	
 	
-	--Nose Aircraft Numbers (USN)
-	--Left
-	{"F18C_BORT_NUMBER_NOSE_L_100", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_L_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_L_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_L_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_NOSE_R_100", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_R_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_R_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_R_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_R_01", DECAL ,"empty",true};	
-		
-	--Flap Aircraft Numbers (USN)
-	--Left
-	{"F18C_BORT_NUMBER_ZAK_L_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_ZAK_L_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_ZAK_L_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_ZAK_R_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_ZAK_R_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_ZAK_R_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_R_01", DECAL ,"empty",true};
+	--*NEW 2.8.4 Bort Numbers*
+	--USN_MODEX_NOSE
+	{"f18c1_number_nose_left"			, DIFFUSE				, "F18C_1_DIFF_VMFA_224_Bengals", false};
+	{"f18c1_number_nose_left"			, SPECULAR				, "F18C_1_DIF_RoughMet", false};
+	{"f18c1_number_nose_left"			, DECAL					, "empty", true};
+	{"f18c1_number_nose_right"			, DIFFUSE				, "F18C_1_DIFF_VMFA_224_Bengals", false};
+	{"f18c1_number_nose_right"			, SPECULAR				, "F18C_1_DIF_RoughMet", false};
+	{"f18c1_number_nose_right"			, DECAL					, "empty", true};
+	--RAAF /KAF/SWITZ_MODEX_FUSELAGE_FRONT_MID_BACK_GEAR_DOORS_SMALL
+	{"f18c1_number_F"					, DIFFUSE				, "F18C_1_DIFF_VMFA_224_Bengals", false};
+	{"f18c1_number_F"					, SPECULAR				, "F18C_1_DIF_RoughMet", false};
+	{"f18c1_number_F"					, DECAL					, "empty", true};
+	--KAF_MODEX_VERTICAL_STABILIZERS_AND_FLAPS_MODEX
+	{"f18c2_number_X"					, DIFFUSE				, "F18C_2_DIFF_VMFA_224_Bengals", false};
+	{"f18c2_number_X"					, SPECULAR				, "F18C_2_DIF_RoughMet", false};
+	{"f18c2_number_X"					, DECAL					, "empty", true};
+	--USN_MODEX_VERTICAL_STABILIZERS
+	{"f18c2_kil_left"					, DIFFUSE				, "F18C_2_DIFF_VMFA_224_Bengals", false};
+	{"f18c2_kil_left"					, SPECULAR				, "F18C_2_DIF_RoughMet", false};
+	{"f18c2_kil_left"					, DECAL					, "empty", true};
+	{"f18c2_kil_right"					, DIFFUSE				, "F18C_2_DIFF_VMFA_224_Bengals", false};
+	{"f18c2_kil_right"					, SPECULAR				, "F18C_2_DIF_RoughMet", false};
+	{"f18c2_kil_right"					, DECAL					, "empty", true};	
 	
-	--Vertical Stab Aircraft Numbers (USN)
-	--Left
-	{"F18C_BORT_NUMBER_KIL_L_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_L_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_L_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_L_01", DECAL ,"empty",true};	
-	--Right
-	{"F18C_BORT_NUMBER_KIL_R_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_R_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_R_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_R_01", DECAL ,"empty",true};		
-
-	--Nose Aircraft Numbers (KUWAIT)
-	--Left
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_100", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_100", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_01", DECAL ,"empty",true};		
 	
+	--(0.0 = ON, 1.0 OFF)
 
-	--Vertical Stab Numbers (KUWAIT)
-	--Right
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_01", DECAL ,"empty",true};		
-
-	--Nose Aircraft Numbers (FINLAND)
-	--Left
-	{"F18C_BORT_NUMBER_NOSE_fin_L_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_fin_L_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_NOSE_fin_R_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_fin_R_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_01", DECAL ,"empty",true};			
-
-	--Vertical Tail Numbers (SWITZERLAND)
-	--Right
-	{"F18C_BORT_NUMBER_KIL_Switz_R_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Switz_R_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_KIL_Switz_L_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Switz_L_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_01", DECAL ,"empty",true};
-
-	--Gear Door Numbers (RAAF)
-	--Right
-	{"F18C_BORT_NUMBER_STV_aus_R_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_STV_aus_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_STV_aus_R_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_STV_aus_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_STV_aus_L_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_STV_aus_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_STV_aus_L_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_STV_aus_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_L_01", DECAL ,"empty",true};		
-		
-	--Aft Fuselage Numbers (RAAF)
-	--Right
-	{"F18C_BORT_NUMBER_MTW_aus_R_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_MTW_aus_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_MTW_aus_R_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_MTW_aus_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_MTW_aus_L_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_MTW_aus_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_MTW_aus_L_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_MTW_aus_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_L_01", DECAL ,"empty",true};		
+	
 }
+
+custom_args = {
+	[0027] = 1.0, -- USN_MODEX_VERTICAL_STABILIZERS
+	[1000] = 1.0, -- USN_MODEX_FLAPS
+	[1001] = 1.0, -- USN_MODEX_NOSE
+	[1002] = 1.0, -- KUWAIT_MODEX_NOSE_AND_VERTICAL_STABILIZERS
+	[1003] = 1.0, -- AUSTRAILIA_MODEX_REAR_FUSELAGE_AND_GEAR_DOORS
+	[1004] = 1.0, -- FINLAND_MODEX_FORWARD_FUSELAGE
+	[1005] = 1.0, -- SWITZERLAND_MODEX_VERTICAL_STABILIZERS
+}
+
 name = "VMFA(AW)-224 Fighting Bengals - 403 - Astroturf - OPSO HiViz"
 

--- a/FA-18C_hornet/VMFA-224 - 404 - Shady/description.lua
+++ b/FA-18C_hornet/VMFA-224 - 404 - Shady/description.lua
@@ -12,6 +12,30 @@ livery = {
 	{"pilot_F18", 0 ,"../VMFA-224 - 000 - Line/pilot_F18",false};
 	{"pilot_F18", 2 ,"pilot_F18_roughmet",true};
 	
+	--Grey Naval bombs
+	{"GBU_12",	DIFFUSE			,	"gbu_12t_gray_diff", true};
+	{"GBU_12",	NORMAL_MAP			,	"gbu_12_nm", true};
+	{"GBU_12",	ROUGHNESS_METALLIC			,	"gbu_12_diff_roughmet", true};
+	{"MK_82", DIFFUSE, "mk_82t_grey_diff", true};
+	{"MK_82", NORMAL_MAP, "mk_82_nm", true};
+	{"MK_82", ROUGHNESS_METALLIC, "mk_82_diff_roughmet", true};
+	{"mk_83", DIFFUSE, "mk_83tgrey_diff", true};
+	{"mk_83", NORMAL_MAP, "mk_83_nm", true};
+	{"mk_83", ROUGHNESS_METALLIC, "mk_83_diff_roughmet", true};
+	{"GBU_38", DIFFUSE, "gbu_38t_diff", true};
+	{"GBU_38", NORMAL_MAP, "gbu_38_nm", true};
+	{"GBU_38", ROUGHNESS_METALLIC, "gbu_38_diff_roughmet", true};
+	{"GBU_31", DIFFUSE, "gbu_31t_gray_diff", true};
+	{"GBU_31", NORMAL_MAP, "gbu_31_nm", true};
+	{"GBU_31", ROUGHNESS_METALLIC, "gbu_31_diff_roughmet", true};
+	{"mk_84", NORMAL_MAP, "mk_84_nm", true};
+	{"mk_84", ROUGHNESS_METALLIC, "mk_84_diff_roughmet", true};
+	{"GBU_10", DIFFUSE, "gbu_10_diff", true};
+	{"GBU_10", NORMAL_MAP, "gbu_10_nm", true};
+	{"GBU_10", ROUGHNESS_METALLIC, "gbu_10_diff_roughmet", true};
+	{"GBU_16", DIFFUSE, "gbu_16t_gray_diff", true};
+	{"GBU_16", NORMAL_MAP, "gbu_16t_nm", true};
+	{"GBU_16", ROUGHNESS_METALLIC, "gbu_16t_gray_diff_roughmet", true};
 	
 	--Fuel Tanks
 	{"FPU_8A", 0 ,"../VMFA-224 - 000 - Line/FPU_8A1",false};

--- a/FA-18C_hornet/VMFA-224 - 404 - Shady/description.lua.bak
+++ b/FA-18C_hornet/VMFA-224 - 404 - Shady/description.lua.bak
@@ -17,186 +17,45 @@ livery = {
 	{"FPU_8A", 0 ,"../VMFA-224 - 000 - Line/FPU_8A1",false};
 	{"FPU_8A", ROUGHNESS_METALLIC ,"FPU_8A_Diff_RoughMet",true};	
 	
-	--Nose Aircraft Numbers (USN)
-	--Left
-	{"F18C_BORT_NUMBER_NOSE_L_100", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_L_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_L_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_L_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_NOSE_R_100", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_R_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_R_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_R_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_R_01", DECAL ,"empty",true};	
-		
-	--Flap Aircraft Numbers (USN)
-	--Left
-	{"F18C_BORT_NUMBER_ZAK_L_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_ZAK_L_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_ZAK_L_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_ZAK_R_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_ZAK_R_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_ZAK_R_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_R_01", DECAL ,"empty",true};
+	--*NEW 2.8.4 Bort Numbers*
+	--USN_MODEX_NOSE
+	{"f18c1_number_nose_left"			, DIFFUSE				, "F18C_1_DIFF_VMFA_224_Bengals", false};
+	{"f18c1_number_nose_left"			, SPECULAR				, "F18C_1_DIF_RoughMet", false};
+	{"f18c1_number_nose_left"			, DECAL					, "empty", true};
+	{"f18c1_number_nose_right"			, DIFFUSE				, "F18C_1_DIFF_VMFA_224_Bengals", false};
+	{"f18c1_number_nose_right"			, SPECULAR				, "F18C_1_DIF_RoughMet", false};
+	{"f18c1_number_nose_right"			, DECAL					, "empty", true};
+	--RAAF /KAF/SWITZ_MODEX_FUSELAGE_FRONT_MID_BACK_GEAR_DOORS_SMALL
+	{"f18c1_number_F"					, DIFFUSE				, "F18C_1_DIFF_VMFA_224_Bengals", false};
+	{"f18c1_number_F"					, SPECULAR				, "F18C_1_DIF_RoughMet", false};
+	{"f18c1_number_F"					, DECAL					, "empty", true};
+	--KAF_MODEX_VERTICAL_STABILIZERS_AND_FLAPS_MODEX
+	{"f18c2_number_X"					, DIFFUSE				, "F18C_2_DIFF_VMFA_224_Bengals", false};
+	{"f18c2_number_X"					, SPECULAR				, "F18C_2_DIF_RoughMet", false};
+	{"f18c2_number_X"					, DECAL					, "empty", true};
+	--USN_MODEX_VERTICAL_STABILIZERS
+	{"f18c2_kil_left"					, DIFFUSE				, "F18C_2_DIFF_VMFA_224_Bengals", false};
+	{"f18c2_kil_left"					, SPECULAR				, "F18C_2_DIF_RoughMet", false};
+	{"f18c2_kil_left"					, DECAL					, "empty", true};
+	{"f18c2_kil_right"					, DIFFUSE				, "F18C_2_DIFF_VMFA_224_Bengals", false};
+	{"f18c2_kil_right"					, SPECULAR				, "F18C_2_DIF_RoughMet", false};
+	{"f18c2_kil_right"					, DECAL					, "empty", true};	
 	
-	--Vertical Stab Aircraft Numbers (USN)
-	--Left
-	{"F18C_BORT_NUMBER_KIL_L_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_L_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_L_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_L_01", DECAL ,"empty",true};	
-	--Right
-	{"F18C_BORT_NUMBER_KIL_R_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_R_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_R_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_R_01", DECAL ,"empty",true};		
-
-	--Nose Aircraft Numbers (KUWAIT)
-	--Left
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_100", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_100", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_01", DECAL ,"empty",true};		
 	
+	--(0.0 = ON, 1.0 OFF)
 
-	--Vertical Stab Numbers (KUWAIT)
-	--Right
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_01", DECAL ,"empty",true};		
-
-	--Nose Aircraft Numbers (FINLAND)
-	--Left
-	{"F18C_BORT_NUMBER_NOSE_fin_L_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_fin_L_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_NOSE_fin_R_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_fin_R_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_01", DECAL ,"empty",true};			
-
-	--Vertical Tail Numbers (SWITZERLAND)
-	--Right
-	{"F18C_BORT_NUMBER_KIL_Switz_R_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Switz_R_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_KIL_Switz_L_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Switz_L_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_01", DECAL ,"empty",true};
-
-	--Gear Door Numbers (RAAF)
-	--Right
-	{"F18C_BORT_NUMBER_STV_aus_R_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_STV_aus_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_STV_aus_R_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_STV_aus_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_STV_aus_L_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_STV_aus_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_STV_aus_L_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_STV_aus_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_L_01", DECAL ,"empty",true};		
-		
-	--Aft Fuselage Numbers (RAAF)
-	--Right
-	{"F18C_BORT_NUMBER_MTW_aus_R_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_MTW_aus_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_MTW_aus_R_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_MTW_aus_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_MTW_aus_L_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_MTW_aus_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_MTW_aus_L_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_MTW_aus_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_L_01", DECAL ,"empty",true};		
+	
 }
+
+custom_args = {
+	[0027] = 1.0, -- USN_MODEX_VERTICAL_STABILIZERS
+	[1000] = 1.0, -- USN_MODEX_FLAPS
+	[1001] = 1.0, -- USN_MODEX_NOSE
+	[1002] = 1.0, -- KUWAIT_MODEX_NOSE_AND_VERTICAL_STABILIZERS
+	[1003] = 1.0, -- AUSTRAILIA_MODEX_REAR_FUSELAGE_AND_GEAR_DOORS
+	[1004] = 1.0, -- FINLAND_MODEX_FORWARD_FUSELAGE
+	[1005] = 1.0, -- SWITZERLAND_MODEX_VERTICAL_STABILIZERS
+}
+	
 name = "VMFA(AW)-224 Fighting Bengals - 404 - Shady"
 

--- a/FA-18C_hornet/VMFA-224 - 405 - Legs/description.lua
+++ b/FA-18C_hornet/VMFA-224 - 405 - Legs/description.lua
@@ -12,6 +12,30 @@ livery = {
 	{"pilot_F18", 0 ,"../VMFA-224 - 000 - Line/pilot_F18",false};
 	{"pilot_F18", 2 ,"pilot_F18_roughmet",true};
 	
+	--Grey Naval bombs
+	{"GBU_12",	DIFFUSE			,	"gbu_12t_gray_diff", true};
+	{"GBU_12",	NORMAL_MAP			,	"gbu_12_nm", true};
+	{"GBU_12",	ROUGHNESS_METALLIC			,	"gbu_12_diff_roughmet", true};
+	{"MK_82", DIFFUSE, "mk_82t_grey_diff", true};
+	{"MK_82", NORMAL_MAP, "mk_82_nm", true};
+	{"MK_82", ROUGHNESS_METALLIC, "mk_82_diff_roughmet", true};
+	{"mk_83", DIFFUSE, "mk_83tgrey_diff", true};
+	{"mk_83", NORMAL_MAP, "mk_83_nm", true};
+	{"mk_83", ROUGHNESS_METALLIC, "mk_83_diff_roughmet", true};
+	{"GBU_38", DIFFUSE, "gbu_38t_diff", true};
+	{"GBU_38", NORMAL_MAP, "gbu_38_nm", true};
+	{"GBU_38", ROUGHNESS_METALLIC, "gbu_38_diff_roughmet", true};
+	{"GBU_31", DIFFUSE, "gbu_31t_gray_diff", true};
+	{"GBU_31", NORMAL_MAP, "gbu_31_nm", true};
+	{"GBU_31", ROUGHNESS_METALLIC, "gbu_31_diff_roughmet", true};
+	{"mk_84", NORMAL_MAP, "mk_84_nm", true};
+	{"mk_84", ROUGHNESS_METALLIC, "mk_84_diff_roughmet", true};
+	{"GBU_10", DIFFUSE, "gbu_10_diff", true};
+	{"GBU_10", NORMAL_MAP, "gbu_10_nm", true};
+	{"GBU_10", ROUGHNESS_METALLIC, "gbu_10_diff_roughmet", true};
+	{"GBU_16", DIFFUSE, "gbu_16t_gray_diff", true};
+	{"GBU_16", NORMAL_MAP, "gbu_16t_nm", true};
+	{"GBU_16", ROUGHNESS_METALLIC, "gbu_16t_gray_diff_roughmet", true};
 	
 	--Fuel Tanks
 	{"FPU_8A", 0 ,"../VMFA-224 - 000 - Line/FPU_8A1",false};

--- a/FA-18C_hornet/VMFA-224 - 405 - Legs/description.lua.bak
+++ b/FA-18C_hornet/VMFA-224 - 405 - Legs/description.lua.bak
@@ -17,186 +17,44 @@ livery = {
 	{"FPU_8A", 0 ,"../VMFA-224 - 000 - Line/FPU_8A1",false};
 	{"FPU_8A", ROUGHNESS_METALLIC ,"FPU_8A_Diff_RoughMet",true};	
 	
-	--Nose Aircraft Numbers (USN)
-	--Left
-	{"F18C_BORT_NUMBER_NOSE_L_100", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_L_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_L_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_L_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_NOSE_R_100", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_R_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_R_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_R_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_R_01", DECAL ,"empty",true};	
-		
-	--Flap Aircraft Numbers (USN)
-	--Left
-	{"F18C_BORT_NUMBER_ZAK_L_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_ZAK_L_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_ZAK_L_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_ZAK_R_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_ZAK_R_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_ZAK_R_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_R_01", DECAL ,"empty",true};
+	--*NEW 2.8.4 Bort Numbers*
+	--USN_MODEX_NOSE
+	{"f18c1_number_nose_left"			, DIFFUSE				, "F18C_1_DIFF_VMFA_224_Bengals", false};
+	{"f18c1_number_nose_left"			, SPECULAR				, "F18C_1_DIF_RoughMet", false};
+	{"f18c1_number_nose_left"			, DECAL					, "empty", true};
+	{"f18c1_number_nose_right"			, DIFFUSE				, "F18C_1_DIFF_VMFA_224_Bengals", false};
+	{"f18c1_number_nose_right"			, SPECULAR				, "F18C_1_DIF_RoughMet", false};
+	{"f18c1_number_nose_right"			, DECAL					, "empty", true};
+	--RAAF /KAF/SWITZ_MODEX_FUSELAGE_FRONT_MID_BACK_GEAR_DOORS_SMALL
+	{"f18c1_number_F"					, DIFFUSE				, "F18C_1_DIFF_VMFA_224_Bengals", false};
+	{"f18c1_number_F"					, SPECULAR				, "F18C_1_DIF_RoughMet", false};
+	{"f18c1_number_F"					, DECAL					, "empty", true};
+	--KAF_MODEX_VERTICAL_STABILIZERS_AND_FLAPS_MODEX
+	{"f18c2_number_X"					, DIFFUSE				, "F18C_2_DIFF_VMFA_224_Bengals", false};
+	{"f18c2_number_X"					, SPECULAR				, "F18C_2_DIF_RoughMet", false};
+	{"f18c2_number_X"					, DECAL					, "empty", true};
+	--USN_MODEX_VERTICAL_STABILIZERS
+	{"f18c2_kil_left"					, DIFFUSE				, "F18C_2_DIFF_VMFA_224_Bengals", false};
+	{"f18c2_kil_left"					, SPECULAR				, "F18C_2_DIF_RoughMet", false};
+	{"f18c2_kil_left"					, DECAL					, "empty", true};
+	{"f18c2_kil_right"					, DIFFUSE				, "F18C_2_DIFF_VMFA_224_Bengals", false};
+	{"f18c2_kil_right"					, SPECULAR				, "F18C_2_DIF_RoughMet", false};
+	{"f18c2_kil_right"					, DECAL					, "empty", true};	
 	
-	--Vertical Stab Aircraft Numbers (USN)
-	--Left
-	{"F18C_BORT_NUMBER_KIL_L_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_L_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_L_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_L_01", DECAL ,"empty",true};	
-	--Right
-	{"F18C_BORT_NUMBER_KIL_R_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_R_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_R_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_R_01", DECAL ,"empty",true};		
-
-	--Nose Aircraft Numbers (KUWAIT)
-	--Left
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_100", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_100", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_01", DECAL ,"empty",true};		
 	
+	--(0.0 = ON, 1.0 OFF)
 
-	--Vertical Stab Numbers (KUWAIT)
-	--Right
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_01", DECAL ,"empty",true};		
+	
+}
 
-	--Nose Aircraft Numbers (FINLAND)
-	--Left
-	{"F18C_BORT_NUMBER_NOSE_fin_L_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_fin_L_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_NOSE_fin_R_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_fin_R_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_01", DECAL ,"empty",true};			
-
-	--Vertical Tail Numbers (SWITZERLAND)
-	--Right
-	{"F18C_BORT_NUMBER_KIL_Switz_R_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Switz_R_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_KIL_Switz_L_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Switz_L_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_01", DECAL ,"empty",true};
-
-	--Gear Door Numbers (RAAF)
-	--Right
-	{"F18C_BORT_NUMBER_STV_aus_R_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_STV_aus_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_STV_aus_R_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_STV_aus_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_STV_aus_L_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_STV_aus_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_STV_aus_L_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_STV_aus_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_L_01", DECAL ,"empty",true};		
-		
-	--Aft Fuselage Numbers (RAAF)
-	--Right
-	{"F18C_BORT_NUMBER_MTW_aus_R_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_MTW_aus_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_MTW_aus_R_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_MTW_aus_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_MTW_aus_L_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_MTW_aus_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_MTW_aus_L_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_MTW_aus_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_L_01", DECAL ,"empty",true};		
+custom_args = {
+	[0027] = 1.0, -- USN_MODEX_VERTICAL_STABILIZERS
+	[1000] = 1.0, -- USN_MODEX_FLAPS
+	[1001] = 1.0, -- USN_MODEX_NOSE
+	[1002] = 1.0, -- KUWAIT_MODEX_NOSE_AND_VERTICAL_STABILIZERS
+	[1003] = 1.0, -- AUSTRAILIA_MODEX_REAR_FUSELAGE_AND_GEAR_DOORS
+	[1004] = 1.0, -- FINLAND_MODEX_FORWARD_FUSELAGE
+	[1005] = 1.0, -- SWITZERLAND_MODEX_VERTICAL_STABILIZERS
 }
 name = "VMFA(AW)-224 Fighting Bengals - 405 - Legs"
 

--- a/FA-18C_hornet/VMFA-224 - 406 - Crauko/description.lua
+++ b/FA-18C_hornet/VMFA-224 - 406 - Crauko/description.lua
@@ -12,6 +12,30 @@ livery = {
 	{"pilot_F18", 0 ,"../VMFA-224 - 000 - Line/pilot_F18",false};
 	{"pilot_F18", 2 ,"pilot_F18_roughmet",true};
 	
+	--Grey Naval bombs
+	{"GBU_12",	DIFFUSE			,	"gbu_12t_gray_diff", true};
+	{"GBU_12",	NORMAL_MAP			,	"gbu_12_nm", true};
+	{"GBU_12",	ROUGHNESS_METALLIC			,	"gbu_12_diff_roughmet", true};
+	{"MK_82", DIFFUSE, "mk_82t_grey_diff", true};
+	{"MK_82", NORMAL_MAP, "mk_82_nm", true};
+	{"MK_82", ROUGHNESS_METALLIC, "mk_82_diff_roughmet", true};
+	{"mk_83", DIFFUSE, "mk_83tgrey_diff", true};
+	{"mk_83", NORMAL_MAP, "mk_83_nm", true};
+	{"mk_83", ROUGHNESS_METALLIC, "mk_83_diff_roughmet", true};
+	{"GBU_38", DIFFUSE, "gbu_38t_diff", true};
+	{"GBU_38", NORMAL_MAP, "gbu_38_nm", true};
+	{"GBU_38", ROUGHNESS_METALLIC, "gbu_38_diff_roughmet", true};
+	{"GBU_31", DIFFUSE, "gbu_31t_gray_diff", true};
+	{"GBU_31", NORMAL_MAP, "gbu_31_nm", true};
+	{"GBU_31", ROUGHNESS_METALLIC, "gbu_31_diff_roughmet", true};
+	{"mk_84", NORMAL_MAP, "mk_84_nm", true};
+	{"mk_84", ROUGHNESS_METALLIC, "mk_84_diff_roughmet", true};
+	{"GBU_10", DIFFUSE, "gbu_10_diff", true};
+	{"GBU_10", NORMAL_MAP, "gbu_10_nm", true};
+	{"GBU_10", ROUGHNESS_METALLIC, "gbu_10_diff_roughmet", true};
+	{"GBU_16", DIFFUSE, "gbu_16t_gray_diff", true};
+	{"GBU_16", NORMAL_MAP, "gbu_16t_nm", true};
+	{"GBU_16", ROUGHNESS_METALLIC, "gbu_16t_gray_diff_roughmet", true};
 	
 	--Fuel Tanks
 	{"FPU_8A", 0 ,"../VMFA-224 - 000 - Line/FPU_8A1",false};

--- a/FA-18C_hornet/VMFA-224 - 406 - Crauko/description.lua.bak
+++ b/FA-18C_hornet/VMFA-224 - 406 - Crauko/description.lua.bak
@@ -17,186 +17,44 @@ livery = {
 	{"FPU_8A", 0 ,"../VMFA-224 - 000 - Line/FPU_8A1",false};
 	{"FPU_8A", ROUGHNESS_METALLIC ,"FPU_8A_Diff_RoughMet",true};	
 	
-	--Nose Aircraft Numbers (USN)
-	--Left
-	{"F18C_BORT_NUMBER_NOSE_L_100", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_L_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_L_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_L_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_NOSE_R_100", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_R_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_R_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_R_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_R_01", DECAL ,"empty",true};	
-		
-	--Flap Aircraft Numbers (USN)
-	--Left
-	{"F18C_BORT_NUMBER_ZAK_L_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_ZAK_L_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_ZAK_L_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_ZAK_R_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_ZAK_R_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_ZAK_R_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_R_01", DECAL ,"empty",true};
+	--*NEW 2.8.4 Bort Numbers*
+	--USN_MODEX_NOSE
+	{"f18c1_number_nose_left"			, DIFFUSE				, "F18C_1_DIFF_VMFA_224_Bengals", false};
+	{"f18c1_number_nose_left"			, SPECULAR				, "F18C_1_DIF_RoughMet", false};
+	{"f18c1_number_nose_left"			, DECAL					, "empty", true};
+	{"f18c1_number_nose_right"			, DIFFUSE				, "F18C_1_DIFF_VMFA_224_Bengals", false};
+	{"f18c1_number_nose_right"			, SPECULAR				, "F18C_1_DIF_RoughMet", false};
+	{"f18c1_number_nose_right"			, DECAL					, "empty", true};
+	--RAAF /KAF/SWITZ_MODEX_FUSELAGE_FRONT_MID_BACK_GEAR_DOORS_SMALL
+	{"f18c1_number_F"					, DIFFUSE				, "F18C_1_DIFF_VMFA_224_Bengals", false};
+	{"f18c1_number_F"					, SPECULAR				, "F18C_1_DIF_RoughMet", false};
+	{"f18c1_number_F"					, DECAL					, "empty", true};
+	--KAF_MODEX_VERTICAL_STABILIZERS_AND_FLAPS_MODEX
+	{"f18c2_number_X"					, DIFFUSE				, "F18C_2_DIFF_VMFA_224_Bengals", false};
+	{"f18c2_number_X"					, SPECULAR				, "F18C_2_DIF_RoughMet", false};
+	{"f18c2_number_X"					, DECAL					, "empty", true};
+	--USN_MODEX_VERTICAL_STABILIZERS
+	{"f18c2_kil_left"					, DIFFUSE				, "F18C_2_DIFF_VMFA_224_Bengals", false};
+	{"f18c2_kil_left"					, SPECULAR				, "F18C_2_DIF_RoughMet", false};
+	{"f18c2_kil_left"					, DECAL					, "empty", true};
+	{"f18c2_kil_right"					, DIFFUSE				, "F18C_2_DIFF_VMFA_224_Bengals", false};
+	{"f18c2_kil_right"					, SPECULAR				, "F18C_2_DIF_RoughMet", false};
+	{"f18c2_kil_right"					, DECAL					, "empty", true};	
 	
-	--Vertical Stab Aircraft Numbers (USN)
-	--Left
-	{"F18C_BORT_NUMBER_KIL_L_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_L_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_L_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_L_01", DECAL ,"empty",true};	
-	--Right
-	{"F18C_BORT_NUMBER_KIL_R_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_R_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_R_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_R_01", DECAL ,"empty",true};		
-
-	--Nose Aircraft Numbers (KUWAIT)
-	--Left
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_100", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_100", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_01", DECAL ,"empty",true};		
 	
+	--(0.0 = ON, 1.0 OFF)
 
-	--Vertical Stab Numbers (KUWAIT)
-	--Right
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_01", DECAL ,"empty",true};		
+	
+}
 
-	--Nose Aircraft Numbers (FINLAND)
-	--Left
-	{"F18C_BORT_NUMBER_NOSE_fin_L_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_fin_L_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_NOSE_fin_R_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_fin_R_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_01", DECAL ,"empty",true};			
-
-	--Vertical Tail Numbers (SWITZERLAND)
-	--Right
-	{"F18C_BORT_NUMBER_KIL_Switz_R_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Switz_R_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_KIL_Switz_L_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Switz_L_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_01", DECAL ,"empty",true};
-
-	--Gear Door Numbers (RAAF)
-	--Right
-	{"F18C_BORT_NUMBER_STV_aus_R_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_STV_aus_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_STV_aus_R_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_STV_aus_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_STV_aus_L_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_STV_aus_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_STV_aus_L_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_STV_aus_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_L_01", DECAL ,"empty",true};		
-		
-	--Aft Fuselage Numbers (RAAF)
-	--Right
-	{"F18C_BORT_NUMBER_MTW_aus_R_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_MTW_aus_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_MTW_aus_R_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_MTW_aus_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_MTW_aus_L_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_MTW_aus_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_MTW_aus_L_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_MTW_aus_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_L_01", DECAL ,"empty",true};		
+custom_args = {
+	[0027] = 1.0, -- USN_MODEX_VERTICAL_STABILIZERS
+	[1000] = 1.0, -- USN_MODEX_FLAPS
+	[1001] = 1.0, -- USN_MODEX_NOSE
+	[1002] = 1.0, -- KUWAIT_MODEX_NOSE_AND_VERTICAL_STABILIZERS
+	[1003] = 1.0, -- AUSTRAILIA_MODEX_REAR_FUSELAGE_AND_GEAR_DOORS
+	[1004] = 1.0, -- FINLAND_MODEX_FORWARD_FUSELAGE
+	[1005] = 1.0, -- SWITZERLAND_MODEX_VERTICAL_STABILIZERS
 }
 name = "VMFA(AW)-224 Fighting Bengals - 406 - Crauko"
 

--- a/FA-18C_hornet/VMFA-224 - 410 - Collider/description.lua
+++ b/FA-18C_hornet/VMFA-224 - 410 - Collider/description.lua
@@ -12,6 +12,30 @@ livery = {
 	{"pilot_F18", 0 ,"../VMFA-224 - 000 - Line/pilot_F18",false};
 	{"pilot_F18", 2 ,"pilot_F18_roughmet",true};
 	
+	--Grey Naval bombs
+	{"GBU_12",	DIFFUSE			,	"gbu_12t_gray_diff", true};
+	{"GBU_12",	NORMAL_MAP			,	"gbu_12_nm", true};
+	{"GBU_12",	ROUGHNESS_METALLIC			,	"gbu_12_diff_roughmet", true};
+	{"MK_82", DIFFUSE, "mk_82t_grey_diff", true};
+	{"MK_82", NORMAL_MAP, "mk_82_nm", true};
+	{"MK_82", ROUGHNESS_METALLIC, "mk_82_diff_roughmet", true};
+	{"mk_83", DIFFUSE, "mk_83tgrey_diff", true};
+	{"mk_83", NORMAL_MAP, "mk_83_nm", true};
+	{"mk_83", ROUGHNESS_METALLIC, "mk_83_diff_roughmet", true};
+	{"GBU_38", DIFFUSE, "gbu_38t_diff", true};
+	{"GBU_38", NORMAL_MAP, "gbu_38_nm", true};
+	{"GBU_38", ROUGHNESS_METALLIC, "gbu_38_diff_roughmet", true};
+	{"GBU_31", DIFFUSE, "gbu_31t_gray_diff", true};
+	{"GBU_31", NORMAL_MAP, "gbu_31_nm", true};
+	{"GBU_31", ROUGHNESS_METALLIC, "gbu_31_diff_roughmet", true};
+	{"mk_84", NORMAL_MAP, "mk_84_nm", true};
+	{"mk_84", ROUGHNESS_METALLIC, "mk_84_diff_roughmet", true};
+	{"GBU_10", DIFFUSE, "gbu_10_diff", true};
+	{"GBU_10", NORMAL_MAP, "gbu_10_nm", true};
+	{"GBU_10", ROUGHNESS_METALLIC, "gbu_10_diff_roughmet", true};
+	{"GBU_16", DIFFUSE, "gbu_16t_gray_diff", true};
+	{"GBU_16", NORMAL_MAP, "gbu_16t_nm", true};
+	{"GBU_16", ROUGHNESS_METALLIC, "gbu_16t_gray_diff_roughmet", true};
 	
 	--Fuel Tanks
 	{"FPU_8A", 0 ,"../VMFA-224 - 000 - Line/FPU_8A1",false};

--- a/FA-18C_hornet/VMFA-224 - 410 - Collider/description.lua.bak
+++ b/FA-18C_hornet/VMFA-224 - 410 - Collider/description.lua.bak
@@ -17,186 +17,44 @@ livery = {
 	{"FPU_8A", 0 ,"../VMFA-224 - 000 - Line/FPU_8A1",false};
 	{"FPU_8A", ROUGHNESS_METALLIC ,"FPU_8A_Diff_RoughMet",true};	
 	
-	--Nose Aircraft Numbers (USN)
-	--Left
-	{"F18C_BORT_NUMBER_NOSE_L_100", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_L_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_L_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_L_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_NOSE_R_100", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_R_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_R_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_R_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_R_01", DECAL ,"empty",true};	
-		
-	--Flap Aircraft Numbers (USN)
-	--Left
-	{"F18C_BORT_NUMBER_ZAK_L_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_ZAK_L_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_ZAK_L_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_ZAK_R_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_ZAK_R_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_ZAK_R_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_R_01", DECAL ,"empty",true};
+	--*NEW 2.8.4 Bort Numbers*
+	--USN_MODEX_NOSE
+	{"f18c1_number_nose_left"			, DIFFUSE				, "F18C_1_DIFF_VMFA_224_Bengals", false};
+	{"f18c1_number_nose_left"			, SPECULAR				, "F18C_1_DIF_RoughMet", false};
+	{"f18c1_number_nose_left"			, DECAL					, "empty", true};
+	{"f18c1_number_nose_right"			, DIFFUSE				, "F18C_1_DIFF_VMFA_224_Bengals", false};
+	{"f18c1_number_nose_right"			, SPECULAR				, "F18C_1_DIF_RoughMet", false};
+	{"f18c1_number_nose_right"			, DECAL					, "empty", true};
+	--RAAF /KAF/SWITZ_MODEX_FUSELAGE_FRONT_MID_BACK_GEAR_DOORS_SMALL
+	{"f18c1_number_F"					, DIFFUSE				, "F18C_1_DIFF_VMFA_224_Bengals", false};
+	{"f18c1_number_F"					, SPECULAR				, "F18C_1_DIF_RoughMet", false};
+	{"f18c1_number_F"					, DECAL					, "empty", true};
+	--KAF_MODEX_VERTICAL_STABILIZERS_AND_FLAPS_MODEX
+	{"f18c2_number_X"					, DIFFUSE				, "F18C_2_DIFF_VMFA_224_Bengals", false};
+	{"f18c2_number_X"					, SPECULAR				, "F18C_2_DIF_RoughMet", false};
+	{"f18c2_number_X"					, DECAL					, "empty", true};
+	--USN_MODEX_VERTICAL_STABILIZERS
+	{"f18c2_kil_left"					, DIFFUSE				, "F18C_2_DIFF_VMFA_224_Bengals", false};
+	{"f18c2_kil_left"					, SPECULAR				, "F18C_2_DIF_RoughMet", false};
+	{"f18c2_kil_left"					, DECAL					, "empty", true};
+	{"f18c2_kil_right"					, DIFFUSE				, "F18C_2_DIFF_VMFA_224_Bengals", false};
+	{"f18c2_kil_right"					, SPECULAR				, "F18C_2_DIF_RoughMet", false};
+	{"f18c2_kil_right"					, DECAL					, "empty", true};	
 	
-	--Vertical Stab Aircraft Numbers (USN)
-	--Left
-	{"F18C_BORT_NUMBER_KIL_L_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_L_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_L_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_L_01", DECAL ,"empty",true};	
-	--Right
-	{"F18C_BORT_NUMBER_KIL_R_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_R_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_R_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_R_01", DECAL ,"empty",true};		
-
-	--Nose Aircraft Numbers (KUWAIT)
-	--Left
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_100", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_100", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_01", DECAL ,"empty",true};		
 	
+	--(0.0 = ON, 1.0 OFF)
 
-	--Vertical Stab Numbers (KUWAIT)
-	--Right
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_01", DECAL ,"empty",true};		
+	
+}
 
-	--Nose Aircraft Numbers (FINLAND)
-	--Left
-	{"F18C_BORT_NUMBER_NOSE_fin_L_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_fin_L_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_NOSE_fin_R_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_fin_R_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_01", DECAL ,"empty",true};			
-
-	--Vertical Tail Numbers (SWITZERLAND)
-	--Right
-	{"F18C_BORT_NUMBER_KIL_Switz_R_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Switz_R_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_KIL_Switz_L_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Switz_L_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_01", DECAL ,"empty",true};
-
-	--Gear Door Numbers (RAAF)
-	--Right
-	{"F18C_BORT_NUMBER_STV_aus_R_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_STV_aus_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_STV_aus_R_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_STV_aus_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_STV_aus_L_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_STV_aus_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_STV_aus_L_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_STV_aus_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_L_01", DECAL ,"empty",true};		
-		
-	--Aft Fuselage Numbers (RAAF)
-	--Right
-	{"F18C_BORT_NUMBER_MTW_aus_R_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_MTW_aus_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_MTW_aus_R_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_MTW_aus_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_MTW_aus_L_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_MTW_aus_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_MTW_aus_L_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_MTW_aus_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_L_01", DECAL ,"empty",true};		
+custom_args = {
+	[0027] = 1.0, -- USN_MODEX_VERTICAL_STABILIZERS
+	[1000] = 1.0, -- USN_MODEX_FLAPS
+	[1001] = 1.0, -- USN_MODEX_NOSE
+	[1002] = 1.0, -- KUWAIT_MODEX_NOSE_AND_VERTICAL_STABILIZERS
+	[1003] = 1.0, -- AUSTRAILIA_MODEX_REAR_FUSELAGE_AND_GEAR_DOORS
+	[1004] = 1.0, -- FINLAND_MODEX_FORWARD_FUSELAGE
+	[1005] = 1.0, -- SWITZERLAND_MODEX_VERTICAL_STABILIZERS
 }
 name = "VMFA(AW)-224 Fighting Bengals - 410 - Collider"
 

--- a/FA-18C_hornet/VMFA-224 - 411 - Chamby/description.lua
+++ b/FA-18C_hornet/VMFA-224 - 411 - Chamby/description.lua
@@ -12,6 +12,30 @@ livery = {
 	{"pilot_F18", 0 ,"../VMFA-224 - 000 - Line/pilot_F18",false};
 	{"pilot_F18", 2 ,"pilot_F18_roughmet",true};
 	
+	--Grey Naval bombs
+	{"GBU_12",	DIFFUSE			,	"gbu_12t_gray_diff", true};
+	{"GBU_12",	NORMAL_MAP			,	"gbu_12_nm", true};
+	{"GBU_12",	ROUGHNESS_METALLIC			,	"gbu_12_diff_roughmet", true};
+	{"MK_82", DIFFUSE, "mk_82t_grey_diff", true};
+	{"MK_82", NORMAL_MAP, "mk_82_nm", true};
+	{"MK_82", ROUGHNESS_METALLIC, "mk_82_diff_roughmet", true};
+	{"mk_83", DIFFUSE, "mk_83tgrey_diff", true};
+	{"mk_83", NORMAL_MAP, "mk_83_nm", true};
+	{"mk_83", ROUGHNESS_METALLIC, "mk_83_diff_roughmet", true};
+	{"GBU_38", DIFFUSE, "gbu_38t_diff", true};
+	{"GBU_38", NORMAL_MAP, "gbu_38_nm", true};
+	{"GBU_38", ROUGHNESS_METALLIC, "gbu_38_diff_roughmet", true};
+	{"GBU_31", DIFFUSE, "gbu_31t_gray_diff", true};
+	{"GBU_31", NORMAL_MAP, "gbu_31_nm", true};
+	{"GBU_31", ROUGHNESS_METALLIC, "gbu_31_diff_roughmet", true};
+	{"mk_84", NORMAL_MAP, "mk_84_nm", true};
+	{"mk_84", ROUGHNESS_METALLIC, "mk_84_diff_roughmet", true};
+	{"GBU_10", DIFFUSE, "gbu_10_diff", true};
+	{"GBU_10", NORMAL_MAP, "gbu_10_nm", true};
+	{"GBU_10", ROUGHNESS_METALLIC, "gbu_10_diff_roughmet", true};
+	{"GBU_16", DIFFUSE, "gbu_16t_gray_diff", true};
+	{"GBU_16", NORMAL_MAP, "gbu_16t_nm", true};
+	{"GBU_16", ROUGHNESS_METALLIC, "gbu_16t_gray_diff_roughmet", true};
 	
 	--Fuel Tanks
 	{"FPU_8A", 0 ,"../VMFA-224 - 000 - Line/FPU_8A1",false};

--- a/FA-18C_hornet/VMFA-224 - 411 - Chamby/description.lua.bak
+++ b/FA-18C_hornet/VMFA-224 - 411 - Chamby/description.lua.bak
@@ -7,7 +7,7 @@ livery = {
 	{"f18c2", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
 	
 	--Pilot Maps
-	{"pilot_F18_helmet", 0, "pilot_F18_helmet_dangles", false};
+	{"pilot_F18_helmet", 0,"../VMFA-224 - 000 - Line/pilot_F18_helmet2", false};
 	{"pilot_F18_patch", 0 ,"../VMFA-224 - 000 - Line/Hornet_Pilot_Patch",false};
 	{"pilot_F18", 0 ,"../VMFA-224 - 000 - Line/pilot_F18",false};
 	{"pilot_F18", 2 ,"pilot_F18_roughmet",true};

--- a/FA-18C_hornet/VMFA-224 - 412 - Firesale/description.lua
+++ b/FA-18C_hornet/VMFA-224 - 412 - Firesale/description.lua
@@ -12,6 +12,30 @@ livery = {
 	{"pilot_F18", 0 ,"../VMFA-224 - 000 - Line/pilot_F18",false};
 	{"pilot_F18", 2 ,"pilot_F18_roughmet",true};
 	
+	--Grey Naval bombs
+	{"GBU_12",	DIFFUSE			,	"gbu_12t_gray_diff", true};
+	{"GBU_12",	NORMAL_MAP			,	"gbu_12_nm", true};
+	{"GBU_12",	ROUGHNESS_METALLIC			,	"gbu_12_diff_roughmet", true};
+	{"MK_82", DIFFUSE, "mk_82t_grey_diff", true};
+	{"MK_82", NORMAL_MAP, "mk_82_nm", true};
+	{"MK_82", ROUGHNESS_METALLIC, "mk_82_diff_roughmet", true};
+	{"mk_83", DIFFUSE, "mk_83tgrey_diff", true};
+	{"mk_83", NORMAL_MAP, "mk_83_nm", true};
+	{"mk_83", ROUGHNESS_METALLIC, "mk_83_diff_roughmet", true};
+	{"GBU_38", DIFFUSE, "gbu_38t_diff", true};
+	{"GBU_38", NORMAL_MAP, "gbu_38_nm", true};
+	{"GBU_38", ROUGHNESS_METALLIC, "gbu_38_diff_roughmet", true};
+	{"GBU_31", DIFFUSE, "gbu_31t_gray_diff", true};
+	{"GBU_31", NORMAL_MAP, "gbu_31_nm", true};
+	{"GBU_31", ROUGHNESS_METALLIC, "gbu_31_diff_roughmet", true};
+	{"mk_84", NORMAL_MAP, "mk_84_nm", true};
+	{"mk_84", ROUGHNESS_METALLIC, "mk_84_diff_roughmet", true};
+	{"GBU_10", DIFFUSE, "gbu_10_diff", true};
+	{"GBU_10", NORMAL_MAP, "gbu_10_nm", true};
+	{"GBU_10", ROUGHNESS_METALLIC, "gbu_10_diff_roughmet", true};
+	{"GBU_16", DIFFUSE, "gbu_16t_gray_diff", true};
+	{"GBU_16", NORMAL_MAP, "gbu_16t_nm", true};
+	{"GBU_16", ROUGHNESS_METALLIC, "gbu_16t_gray_diff_roughmet", true};
 	
 	--Fuel Tanks
 	{"FPU_8A", 0 ,"../VMFA-224 - 000 - Line/FPU_8A1",false};

--- a/FA-18C_hornet/VMFA-224 - 412 - Firesale/description.lua.bak
+++ b/FA-18C_hornet/VMFA-224 - 412 - Firesale/description.lua.bak
@@ -17,186 +17,44 @@ livery = {
 	{"FPU_8A", 0 ,"../VMFA-224 - 000 - Line/FPU_8A1",false};
 	{"FPU_8A", ROUGHNESS_METALLIC ,"FPU_8A_Diff_RoughMet",true};	
 	
-	--Nose Aircraft Numbers (USN)
-	--Left
-	{"F18C_BORT_NUMBER_NOSE_L_100", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_L_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_L_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_L_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_NOSE_R_100", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_R_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_R_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_R_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_R_01", DECAL ,"empty",true};	
-		
-	--Flap Aircraft Numbers (USN)
-	--Left
-	{"F18C_BORT_NUMBER_ZAK_L_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_ZAK_L_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_ZAK_L_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_ZAK_R_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_ZAK_R_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_ZAK_R_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_R_01", DECAL ,"empty",true};
+	--*NEW 2.8.4 Bort Numbers*
+	--USN_MODEX_NOSE
+	{"f18c1_number_nose_left"			, DIFFUSE				, "F18C_1_DIFF_VMFA_224_Bengals", false};
+	{"f18c1_number_nose_left"			, SPECULAR				, "F18C_1_DIF_RoughMet", false};
+	{"f18c1_number_nose_left"			, DECAL					, "empty", true};
+	{"f18c1_number_nose_right"			, DIFFUSE				, "F18C_1_DIFF_VMFA_224_Bengals", false};
+	{"f18c1_number_nose_right"			, SPECULAR				, "F18C_1_DIF_RoughMet", false};
+	{"f18c1_number_nose_right"			, DECAL					, "empty", true};
+	--RAAF /KAF/SWITZ_MODEX_FUSELAGE_FRONT_MID_BACK_GEAR_DOORS_SMALL
+	{"f18c1_number_F"					, DIFFUSE				, "F18C_1_DIFF_VMFA_224_Bengals", false};
+	{"f18c1_number_F"					, SPECULAR				, "F18C_1_DIF_RoughMet", false};
+	{"f18c1_number_F"					, DECAL					, "empty", true};
+	--KAF_MODEX_VERTICAL_STABILIZERS_AND_FLAPS_MODEX
+	{"f18c2_number_X"					, DIFFUSE				, "F18C_2_DIFF_VMFA_224_Bengals", false};
+	{"f18c2_number_X"					, SPECULAR				, "F18C_2_DIF_RoughMet", false};
+	{"f18c2_number_X"					, DECAL					, "empty", true};
+	--USN_MODEX_VERTICAL_STABILIZERS
+	{"f18c2_kil_left"					, DIFFUSE				, "F18C_2_DIFF_VMFA_224_Bengals", false};
+	{"f18c2_kil_left"					, SPECULAR				, "F18C_2_DIF_RoughMet", false};
+	{"f18c2_kil_left"					, DECAL					, "empty", true};
+	{"f18c2_kil_right"					, DIFFUSE				, "F18C_2_DIFF_VMFA_224_Bengals", false};
+	{"f18c2_kil_right"					, SPECULAR				, "F18C_2_DIF_RoughMet", false};
+	{"f18c2_kil_right"					, DECAL					, "empty", true};	
 	
-	--Vertical Stab Aircraft Numbers (USN)
-	--Left
-	{"F18C_BORT_NUMBER_KIL_L_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_L_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_L_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_L_01", DECAL ,"empty",true};	
-	--Right
-	{"F18C_BORT_NUMBER_KIL_R_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_R_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_R_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_R_01", DECAL ,"empty",true};		
-
-	--Nose Aircraft Numbers (KUWAIT)
-	--Left
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_100", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_100", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_01", DECAL ,"empty",true};		
 	
+	--(0.0 = ON, 1.0 OFF)
 
-	--Vertical Stab Numbers (KUWAIT)
-	--Right
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_01", DECAL ,"empty",true};		
+	
+}
 
-	--Nose Aircraft Numbers (FINLAND)
-	--Left
-	{"F18C_BORT_NUMBER_NOSE_fin_L_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_fin_L_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_NOSE_fin_R_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_fin_R_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_01", DECAL ,"empty",true};			
-
-	--Vertical Tail Numbers (SWITZERLAND)
-	--Right
-	{"F18C_BORT_NUMBER_KIL_Switz_R_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Switz_R_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_KIL_Switz_L_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Switz_L_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_01", DECAL ,"empty",true};
-
-	--Gear Door Numbers (RAAF)
-	--Right
-	{"F18C_BORT_NUMBER_STV_aus_R_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_STV_aus_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_STV_aus_R_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_STV_aus_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_STV_aus_L_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_STV_aus_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_STV_aus_L_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_STV_aus_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_L_01", DECAL ,"empty",true};		
-		
-	--Aft Fuselage Numbers (RAAF)
-	--Right
-	{"F18C_BORT_NUMBER_MTW_aus_R_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_MTW_aus_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_MTW_aus_R_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_MTW_aus_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_MTW_aus_L_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_MTW_aus_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_MTW_aus_L_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_MTW_aus_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_L_01", DECAL ,"empty",true};		
+custom_args = {
+	[0027] = 1.0, -- USN_MODEX_VERTICAL_STABILIZERS
+	[1000] = 1.0, -- USN_MODEX_FLAPS
+	[1001] = 1.0, -- USN_MODEX_NOSE
+	[1002] = 1.0, -- KUWAIT_MODEX_NOSE_AND_VERTICAL_STABILIZERS
+	[1003] = 1.0, -- AUSTRAILIA_MODEX_REAR_FUSELAGE_AND_GEAR_DOORS
+	[1004] = 1.0, -- FINLAND_MODEX_FORWARD_FUSELAGE
+	[1005] = 1.0, -- SWITZERLAND_MODEX_VERTICAL_STABILIZERS
 }
 name = "VMFA(AW)-224 Fighting Bengals - 412 - Firesale"
 

--- a/FA-18C_hornet/VMFA-224 - 413 - Threefer/description.lua
+++ b/FA-18C_hornet/VMFA-224 - 413 - Threefer/description.lua
@@ -12,6 +12,30 @@ livery = {
 	{"pilot_F18", 0 ,"../VMFA-224 - 000 - Line/pilot_F18",false};
 	{"pilot_F18", 2 ,"pilot_F18_roughmet",true};
 	
+	--Grey Naval bombs
+	{"GBU_12",	DIFFUSE			,	"gbu_12t_gray_diff", true};
+	{"GBU_12",	NORMAL_MAP			,	"gbu_12_nm", true};
+	{"GBU_12",	ROUGHNESS_METALLIC			,	"gbu_12_diff_roughmet", true};
+	{"MK_82", DIFFUSE, "mk_82t_grey_diff", true};
+	{"MK_82", NORMAL_MAP, "mk_82_nm", true};
+	{"MK_82", ROUGHNESS_METALLIC, "mk_82_diff_roughmet", true};
+	{"mk_83", DIFFUSE, "mk_83tgrey_diff", true};
+	{"mk_83", NORMAL_MAP, "mk_83_nm", true};
+	{"mk_83", ROUGHNESS_METALLIC, "mk_83_diff_roughmet", true};
+	{"GBU_38", DIFFUSE, "gbu_38t_diff", true};
+	{"GBU_38", NORMAL_MAP, "gbu_38_nm", true};
+	{"GBU_38", ROUGHNESS_METALLIC, "gbu_38_diff_roughmet", true};
+	{"GBU_31", DIFFUSE, "gbu_31t_gray_diff", true};
+	{"GBU_31", NORMAL_MAP, "gbu_31_nm", true};
+	{"GBU_31", ROUGHNESS_METALLIC, "gbu_31_diff_roughmet", true};
+	{"mk_84", NORMAL_MAP, "mk_84_nm", true};
+	{"mk_84", ROUGHNESS_METALLIC, "mk_84_diff_roughmet", true};
+	{"GBU_10", DIFFUSE, "gbu_10_diff", true};
+	{"GBU_10", NORMAL_MAP, "gbu_10_nm", true};
+	{"GBU_10", ROUGHNESS_METALLIC, "gbu_10_diff_roughmet", true};
+	{"GBU_16", DIFFUSE, "gbu_16t_gray_diff", true};
+	{"GBU_16", NORMAL_MAP, "gbu_16t_nm", true};
+	{"GBU_16", ROUGHNESS_METALLIC, "gbu_16t_gray_diff_roughmet", true};
 	
 	--Fuel Tanks
 	{"FPU_8A", 0 ,"../VMFA-224 - 000 - Line/FPU_8A1",false};

--- a/FA-18C_hornet/VMFA-224 - 413 - Threefer/description.lua.bak
+++ b/FA-18C_hornet/VMFA-224 - 413 - Threefer/description.lua.bak
@@ -17,186 +17,44 @@ livery = {
 	{"FPU_8A", 0 ,"../VMFA-224 - 000 - Line/FPU_8A1",false};
 	{"FPU_8A", ROUGHNESS_METALLIC ,"FPU_8A_Diff_RoughMet",true};	
 	
-	--Nose Aircraft Numbers (USN)
-	--Left
-	{"F18C_BORT_NUMBER_NOSE_L_100", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_L_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_L_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_L_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_NOSE_R_100", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_R_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_R_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_R_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_R_01", DECAL ,"empty",true};	
-		
-	--Flap Aircraft Numbers (USN)
-	--Left
-	{"F18C_BORT_NUMBER_ZAK_L_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_ZAK_L_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_ZAK_L_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_ZAK_R_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_ZAK_R_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_ZAK_R_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_R_01", DECAL ,"empty",true};
+	--*NEW 2.8.4 Bort Numbers*
+	--USN_MODEX_NOSE
+	{"f18c1_number_nose_left"			, DIFFUSE				, "F18C_1_DIFF_VMFA_224_Bengals", false};
+	{"f18c1_number_nose_left"			, SPECULAR				, "F18C_1_DIF_RoughMet", false};
+	{"f18c1_number_nose_left"			, DECAL					, "empty", true};
+	{"f18c1_number_nose_right"			, DIFFUSE				, "F18C_1_DIFF_VMFA_224_Bengals", false};
+	{"f18c1_number_nose_right"			, SPECULAR				, "F18C_1_DIF_RoughMet", false};
+	{"f18c1_number_nose_right"			, DECAL					, "empty", true};
+	--RAAF /KAF/SWITZ_MODEX_FUSELAGE_FRONT_MID_BACK_GEAR_DOORS_SMALL
+	{"f18c1_number_F"					, DIFFUSE				, "F18C_1_DIFF_VMFA_224_Bengals", false};
+	{"f18c1_number_F"					, SPECULAR				, "F18C_1_DIF_RoughMet", false};
+	{"f18c1_number_F"					, DECAL					, "empty", true};
+	--KAF_MODEX_VERTICAL_STABILIZERS_AND_FLAPS_MODEX
+	{"f18c2_number_X"					, DIFFUSE				, "F18C_2_DIFF_VMFA_224_Bengals", false};
+	{"f18c2_number_X"					, SPECULAR				, "F18C_2_DIF_RoughMet", false};
+	{"f18c2_number_X"					, DECAL					, "empty", true};
+	--USN_MODEX_VERTICAL_STABILIZERS
+	{"f18c2_kil_left"					, DIFFUSE				, "F18C_2_DIFF_VMFA_224_Bengals", false};
+	{"f18c2_kil_left"					, SPECULAR				, "F18C_2_DIF_RoughMet", false};
+	{"f18c2_kil_left"					, DECAL					, "empty", true};
+	{"f18c2_kil_right"					, DIFFUSE				, "F18C_2_DIFF_VMFA_224_Bengals", false};
+	{"f18c2_kil_right"					, SPECULAR				, "F18C_2_DIF_RoughMet", false};
+	{"f18c2_kil_right"					, DECAL					, "empty", true};	
 	
-	--Vertical Stab Aircraft Numbers (USN)
-	--Left
-	{"F18C_BORT_NUMBER_KIL_L_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_L_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_L_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_L_01", DECAL ,"empty",true};	
-	--Right
-	{"F18C_BORT_NUMBER_KIL_R_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_R_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_R_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_R_01", DECAL ,"empty",true};		
-
-	--Nose Aircraft Numbers (KUWAIT)
-	--Left
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_100", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_100", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_01", DECAL ,"empty",true};		
 	
+	--(0.0 = ON, 1.0 OFF)
 
-	--Vertical Stab Numbers (KUWAIT)
-	--Right
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_01", DECAL ,"empty",true};		
+	
+}
 
-	--Nose Aircraft Numbers (FINLAND)
-	--Left
-	{"F18C_BORT_NUMBER_NOSE_fin_L_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_fin_L_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_NOSE_fin_R_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_fin_R_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_01", DECAL ,"empty",true};			
-
-	--Vertical Tail Numbers (SWITZERLAND)
-	--Right
-	{"F18C_BORT_NUMBER_KIL_Switz_R_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Switz_R_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_KIL_Switz_L_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Switz_L_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_01", DECAL ,"empty",true};
-
-	--Gear Door Numbers (RAAF)
-	--Right
-	{"F18C_BORT_NUMBER_STV_aus_R_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_STV_aus_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_STV_aus_R_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_STV_aus_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_STV_aus_L_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_STV_aus_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_STV_aus_L_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_STV_aus_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_L_01", DECAL ,"empty",true};		
-		
-	--Aft Fuselage Numbers (RAAF)
-	--Right
-	{"F18C_BORT_NUMBER_MTW_aus_R_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_MTW_aus_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_MTW_aus_R_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_MTW_aus_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_MTW_aus_L_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_MTW_aus_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_MTW_aus_L_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_MTW_aus_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_L_01", DECAL ,"empty",true};		
+custom_args = {
+	[0027] = 1.0, -- USN_MODEX_VERTICAL_STABILIZERS
+	[1000] = 1.0, -- USN_MODEX_FLAPS
+	[1001] = 1.0, -- USN_MODEX_NOSE
+	[1002] = 1.0, -- KUWAIT_MODEX_NOSE_AND_VERTICAL_STABILIZERS
+	[1003] = 1.0, -- AUSTRAILIA_MODEX_REAR_FUSELAGE_AND_GEAR_DOORS
+	[1004] = 1.0, -- FINLAND_MODEX_FORWARD_FUSELAGE
+	[1005] = 1.0, -- SWITZERLAND_MODEX_VERTICAL_STABILIZERS
 }
 name = "VMFA(AW)-224 Fighting Bengals - 413 - Threefer"
 

--- a/FA-18C_hornet/VMFA-224 - 414 - Challenger/description.lua
+++ b/FA-18C_hornet/VMFA-224 - 414 - Challenger/description.lua
@@ -12,6 +12,30 @@ livery = {
 	{"pilot_F18", 0 ,"../VMFA-224 - 000 - Line/pilot_F18",false};
 	{"pilot_F18", 2 ,"pilot_F18_roughmet",true};
 	
+	--Grey Naval bombs
+	{"GBU_12",	DIFFUSE			,	"gbu_12t_gray_diff", true};
+	{"GBU_12",	NORMAL_MAP			,	"gbu_12_nm", true};
+	{"GBU_12",	ROUGHNESS_METALLIC			,	"gbu_12_diff_roughmet", true};
+	{"MK_82", DIFFUSE, "mk_82t_grey_diff", true};
+	{"MK_82", NORMAL_MAP, "mk_82_nm", true};
+	{"MK_82", ROUGHNESS_METALLIC, "mk_82_diff_roughmet", true};
+	{"mk_83", DIFFUSE, "mk_83tgrey_diff", true};
+	{"mk_83", NORMAL_MAP, "mk_83_nm", true};
+	{"mk_83", ROUGHNESS_METALLIC, "mk_83_diff_roughmet", true};
+	{"GBU_38", DIFFUSE, "gbu_38t_diff", true};
+	{"GBU_38", NORMAL_MAP, "gbu_38_nm", true};
+	{"GBU_38", ROUGHNESS_METALLIC, "gbu_38_diff_roughmet", true};
+	{"GBU_31", DIFFUSE, "gbu_31t_gray_diff", true};
+	{"GBU_31", NORMAL_MAP, "gbu_31_nm", true};
+	{"GBU_31", ROUGHNESS_METALLIC, "gbu_31_diff_roughmet", true};
+	{"mk_84", NORMAL_MAP, "mk_84_nm", true};
+	{"mk_84", ROUGHNESS_METALLIC, "mk_84_diff_roughmet", true};
+	{"GBU_10", DIFFUSE, "gbu_10_diff", true};
+	{"GBU_10", NORMAL_MAP, "gbu_10_nm", true};
+	{"GBU_10", ROUGHNESS_METALLIC, "gbu_10_diff_roughmet", true};
+	{"GBU_16", DIFFUSE, "gbu_16t_gray_diff", true};
+	{"GBU_16", NORMAL_MAP, "gbu_16t_nm", true};
+	{"GBU_16", ROUGHNESS_METALLIC, "gbu_16t_gray_diff_roughmet", true};
 	
 	--Fuel Tanks
 	{"FPU_8A", 0 ,"../VMFA-224 - 000 - Line/FPU_8A1",false};

--- a/FA-18C_hornet/VMFA-224 - 414 - Challenger/description.lua.bak
+++ b/FA-18C_hornet/VMFA-224 - 414 - Challenger/description.lua.bak
@@ -17,186 +17,44 @@ livery = {
 	{"FPU_8A", 0 ,"../VMFA-224 - 000 - Line/FPU_8A1",false};
 	{"FPU_8A", ROUGHNESS_METALLIC ,"FPU_8A_Diff_RoughMet",true};	
 	
-	--Nose Aircraft Numbers (USN)
-	--Left
-	{"F18C_BORT_NUMBER_NOSE_L_100", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_L_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_L_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_L_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_NOSE_R_100", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_R_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_R_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_R_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_R_01", DECAL ,"empty",true};	
-		
-	--Flap Aircraft Numbers (USN)
-	--Left
-	{"F18C_BORT_NUMBER_ZAK_L_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_ZAK_L_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_ZAK_L_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_ZAK_R_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_ZAK_R_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_ZAK_R_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_R_01", DECAL ,"empty",true};
+	--*NEW 2.8.4 Bort Numbers*
+	--USN_MODEX_NOSE
+	{"f18c1_number_nose_left"			, DIFFUSE				, "F18C_1_DIFF_VMFA_224_Bengals", false};
+	{"f18c1_number_nose_left"			, SPECULAR				, "F18C_1_DIF_RoughMet", false};
+	{"f18c1_number_nose_left"			, DECAL					, "empty", true};
+	{"f18c1_number_nose_right"			, DIFFUSE				, "F18C_1_DIFF_VMFA_224_Bengals", false};
+	{"f18c1_number_nose_right"			, SPECULAR				, "F18C_1_DIF_RoughMet", false};
+	{"f18c1_number_nose_right"			, DECAL					, "empty", true};
+	--RAAF /KAF/SWITZ_MODEX_FUSELAGE_FRONT_MID_BACK_GEAR_DOORS_SMALL
+	{"f18c1_number_F"					, DIFFUSE				, "F18C_1_DIFF_VMFA_224_Bengals", false};
+	{"f18c1_number_F"					, SPECULAR				, "F18C_1_DIF_RoughMet", false};
+	{"f18c1_number_F"					, DECAL					, "empty", true};
+	--KAF_MODEX_VERTICAL_STABILIZERS_AND_FLAPS_MODEX
+	{"f18c2_number_X"					, DIFFUSE				, "F18C_2_DIFF_VMFA_224_Bengals", false};
+	{"f18c2_number_X"					, SPECULAR				, "F18C_2_DIF_RoughMet", false};
+	{"f18c2_number_X"					, DECAL					, "empty", true};
+	--USN_MODEX_VERTICAL_STABILIZERS
+	{"f18c2_kil_left"					, DIFFUSE				, "F18C_2_DIFF_VMFA_224_Bengals", false};
+	{"f18c2_kil_left"					, SPECULAR				, "F18C_2_DIF_RoughMet", false};
+	{"f18c2_kil_left"					, DECAL					, "empty", true};
+	{"f18c2_kil_right"					, DIFFUSE				, "F18C_2_DIFF_VMFA_224_Bengals", false};
+	{"f18c2_kil_right"					, SPECULAR				, "F18C_2_DIF_RoughMet", false};
+	{"f18c2_kil_right"					, DECAL					, "empty", true};	
 	
-	--Vertical Stab Aircraft Numbers (USN)
-	--Left
-	{"F18C_BORT_NUMBER_KIL_L_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_L_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_L_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_L_01", DECAL ,"empty",true};	
-	--Right
-	{"F18C_BORT_NUMBER_KIL_R_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_R_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_R_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_R_01", DECAL ,"empty",true};		
-
-	--Nose Aircraft Numbers (KUWAIT)
-	--Left
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_100", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_100", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_01", DECAL ,"empty",true};		
 	
+	--(0.0 = ON, 1.0 OFF)
 
-	--Vertical Stab Numbers (KUWAIT)
-	--Right
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_01", DECAL ,"empty",true};		
+	
+}
 
-	--Nose Aircraft Numbers (FINLAND)
-	--Left
-	{"F18C_BORT_NUMBER_NOSE_fin_L_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_fin_L_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_NOSE_fin_R_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_fin_R_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_01", DECAL ,"empty",true};			
-
-	--Vertical Tail Numbers (SWITZERLAND)
-	--Right
-	{"F18C_BORT_NUMBER_KIL_Switz_R_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Switz_R_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_KIL_Switz_L_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Switz_L_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_01", DECAL ,"empty",true};
-
-	--Gear Door Numbers (RAAF)
-	--Right
-	{"F18C_BORT_NUMBER_STV_aus_R_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_STV_aus_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_STV_aus_R_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_STV_aus_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_STV_aus_L_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_STV_aus_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_STV_aus_L_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_STV_aus_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_L_01", DECAL ,"empty",true};		
-		
-	--Aft Fuselage Numbers (RAAF)
-	--Right
-	{"F18C_BORT_NUMBER_MTW_aus_R_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_MTW_aus_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_MTW_aus_R_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_MTW_aus_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_MTW_aus_L_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_MTW_aus_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_MTW_aus_L_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_MTW_aus_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_L_01", DECAL ,"empty",true};		
+custom_args = {
+	[0027] = 1.0, -- USN_MODEX_VERTICAL_STABILIZERS
+	[1000] = 1.0, -- USN_MODEX_FLAPS
+	[1001] = 1.0, -- USN_MODEX_NOSE
+	[1002] = 1.0, -- KUWAIT_MODEX_NOSE_AND_VERTICAL_STABILIZERS
+	[1003] = 1.0, -- AUSTRAILIA_MODEX_REAR_FUSELAGE_AND_GEAR_DOORS
+	[1004] = 1.0, -- FINLAND_MODEX_FORWARD_FUSELAGE
+	[1005] = 1.0, -- SWITZERLAND_MODEX_VERTICAL_STABILIZERS
 }
 name = "VMFA(AW)-224 Fighting Bengals - 414 - Challenger"
 

--- a/FA-18C_hornet/VMFA-224 - 416 - Mayo Memorial/description.lua
+++ b/FA-18C_hornet/VMFA-224 - 416 - Mayo Memorial/description.lua
@@ -12,6 +12,30 @@ livery = {
 	{"pilot_F18", 0 ,"../VMFA-224 - 000 - Line/pilot_F18",false};
 	{"pilot_F18", 2 ,"pilot_F18_roughmet",true};
 	
+	--Grey Naval bombs
+	{"GBU_12",	DIFFUSE			,	"gbu_12t_gray_diff", true};
+	{"GBU_12",	NORMAL_MAP			,	"gbu_12_nm", true};
+	{"GBU_12",	ROUGHNESS_METALLIC			,	"gbu_12_diff_roughmet", true};
+	{"MK_82", DIFFUSE, "mk_82t_grey_diff", true};
+	{"MK_82", NORMAL_MAP, "mk_82_nm", true};
+	{"MK_82", ROUGHNESS_METALLIC, "mk_82_diff_roughmet", true};
+	{"mk_83", DIFFUSE, "mk_83tgrey_diff", true};
+	{"mk_83", NORMAL_MAP, "mk_83_nm", true};
+	{"mk_83", ROUGHNESS_METALLIC, "mk_83_diff_roughmet", true};
+	{"GBU_38", DIFFUSE, "gbu_38t_diff", true};
+	{"GBU_38", NORMAL_MAP, "gbu_38_nm", true};
+	{"GBU_38", ROUGHNESS_METALLIC, "gbu_38_diff_roughmet", true};
+	{"GBU_31", DIFFUSE, "gbu_31t_gray_diff", true};
+	{"GBU_31", NORMAL_MAP, "gbu_31_nm", true};
+	{"GBU_31", ROUGHNESS_METALLIC, "gbu_31_diff_roughmet", true};
+	{"mk_84", NORMAL_MAP, "mk_84_nm", true};
+	{"mk_84", ROUGHNESS_METALLIC, "mk_84_diff_roughmet", true};
+	{"GBU_10", DIFFUSE, "gbu_10_diff", true};
+	{"GBU_10", NORMAL_MAP, "gbu_10_nm", true};
+	{"GBU_10", ROUGHNESS_METALLIC, "gbu_10_diff_roughmet", true};
+	{"GBU_16", DIFFUSE, "gbu_16t_gray_diff", true};
+	{"GBU_16", NORMAL_MAP, "gbu_16t_nm", true};
+	{"GBU_16", ROUGHNESS_METALLIC, "gbu_16t_gray_diff_roughmet", true};
 	
 	--Fuel Tanks
 	{"FPU_8A", 0 ,"../VMFA-224 - 000 - Line/FPU_8A1",false};

--- a/FA-18C_hornet/VMFA-224 - 416 - Mayo Memorial/description.lua.bak
+++ b/FA-18C_hornet/VMFA-224 - 416 - Mayo Memorial/description.lua.bak
@@ -7,7 +7,7 @@ livery = {
 	{"f18c2", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
 	
 	--Pilot Maps
-	{"pilot_F18_helmet", 0, "pilot_F18_helmet_dangles", false};
+	{"pilot_F18_helmet", 0, "pilot_F18_helmet_vfa_mayo", false};
 	{"pilot_F18_patch", 0 ,"../VMFA-224 - 000 - Line/Hornet_Pilot_Patch",false};
 	{"pilot_F18", 0 ,"../VMFA-224 - 000 - Line/pilot_F18",false};
 	{"pilot_F18", 2 ,"pilot_F18_roughmet",true};
@@ -56,5 +56,5 @@ custom_args = {
 	[1004] = 1.0, -- FINLAND_MODEX_FORWARD_FUSELAGE
 	[1005] = 1.0, -- SWITZERLAND_MODEX_VERTICAL_STABILIZERS
 }
-name = "VMFA(AW)-224 Fighting Bengals - 417 - Dangles"
+name = "VMFA(AW)-224 Fighting Bengals - 416 - Mayo Memorial"
 

--- a/FA-18C_hornet/VMFA-224 - 417 - Dangles/description.lua
+++ b/FA-18C_hornet/VMFA-224 - 417 - Dangles/description.lua
@@ -12,6 +12,30 @@ livery = {
 	{"pilot_F18", 0 ,"../VMFA-224 - 000 - Line/pilot_F18",false};
 	{"pilot_F18", 2 ,"pilot_F18_roughmet",true};
 	
+	--Grey Naval bombs
+	{"GBU_12",	DIFFUSE			,	"gbu_12t_gray_diff", true};
+	{"GBU_12",	NORMAL_MAP			,	"gbu_12_nm", true};
+	{"GBU_12",	ROUGHNESS_METALLIC			,	"gbu_12_diff_roughmet", true};
+	{"MK_82", DIFFUSE, "mk_82t_grey_diff", true};
+	{"MK_82", NORMAL_MAP, "mk_82_nm", true};
+	{"MK_82", ROUGHNESS_METALLIC, "mk_82_diff_roughmet", true};
+	{"mk_83", DIFFUSE, "mk_83tgrey_diff", true};
+	{"mk_83", NORMAL_MAP, "mk_83_nm", true};
+	{"mk_83", ROUGHNESS_METALLIC, "mk_83_diff_roughmet", true};
+	{"GBU_38", DIFFUSE, "gbu_38t_diff", true};
+	{"GBU_38", NORMAL_MAP, "gbu_38_nm", true};
+	{"GBU_38", ROUGHNESS_METALLIC, "gbu_38_diff_roughmet", true};
+	{"GBU_31", DIFFUSE, "gbu_31t_gray_diff", true};
+	{"GBU_31", NORMAL_MAP, "gbu_31_nm", true};
+	{"GBU_31", ROUGHNESS_METALLIC, "gbu_31_diff_roughmet", true};
+	{"mk_84", NORMAL_MAP, "mk_84_nm", true};
+	{"mk_84", ROUGHNESS_METALLIC, "mk_84_diff_roughmet", true};
+	{"GBU_10", DIFFUSE, "gbu_10_diff", true};
+	{"GBU_10", NORMAL_MAP, "gbu_10_nm", true};
+	{"GBU_10", ROUGHNESS_METALLIC, "gbu_10_diff_roughmet", true};
+	{"GBU_16", DIFFUSE, "gbu_16t_gray_diff", true};
+	{"GBU_16", NORMAL_MAP, "gbu_16t_nm", true};
+	{"GBU_16", ROUGHNESS_METALLIC, "gbu_16t_gray_diff_roughmet", true};
 	
 	--Fuel Tanks
 	{"FPU_8A", 0 ,"../VMFA-224 - 000 - Line/FPU_8A1",false};

--- a/FA-18C_hornet/VMFA-224 - 417 - Dangles/description.lua.bak
+++ b/FA-18C_hornet/VMFA-224 - 417 - Dangles/description.lua.bak
@@ -17,186 +17,44 @@ livery = {
 	{"FPU_8A", 0 ,"../VMFA-224 - 000 - Line/FPU_8A1",false};
 	{"FPU_8A", ROUGHNESS_METALLIC ,"FPU_8A_Diff_RoughMet",true};	
 	
-	--Nose Aircraft Numbers (USN)
-	--Left
-	{"F18C_BORT_NUMBER_NOSE_L_100", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_L_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_L_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_L_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_NOSE_R_100", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_R_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_R_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_R_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_R_01", DECAL ,"empty",true};	
-		
-	--Flap Aircraft Numbers (USN)
-	--Left
-	{"F18C_BORT_NUMBER_ZAK_L_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_ZAK_L_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_ZAK_L_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_ZAK_R_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_ZAK_R_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_ZAK_R_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_R_01", DECAL ,"empty",true};
+	--*NEW 2.8.4 Bort Numbers*
+	--USN_MODEX_NOSE
+	{"f18c1_number_nose_left"			, DIFFUSE				, "F18C_1_DIFF_VMFA_224_Bengals", false};
+	{"f18c1_number_nose_left"			, SPECULAR				, "F18C_1_DIF_RoughMet", false};
+	{"f18c1_number_nose_left"			, DECAL					, "empty", true};
+	{"f18c1_number_nose_right"			, DIFFUSE				, "F18C_1_DIFF_VMFA_224_Bengals", false};
+	{"f18c1_number_nose_right"			, SPECULAR				, "F18C_1_DIF_RoughMet", false};
+	{"f18c1_number_nose_right"			, DECAL					, "empty", true};
+	--RAAF /KAF/SWITZ_MODEX_FUSELAGE_FRONT_MID_BACK_GEAR_DOORS_SMALL
+	{"f18c1_number_F"					, DIFFUSE				, "F18C_1_DIFF_VMFA_224_Bengals", false};
+	{"f18c1_number_F"					, SPECULAR				, "F18C_1_DIF_RoughMet", false};
+	{"f18c1_number_F"					, DECAL					, "empty", true};
+	--KAF_MODEX_VERTICAL_STABILIZERS_AND_FLAPS_MODEX
+	{"f18c2_number_X"					, DIFFUSE				, "F18C_2_DIFF_VMFA_224_Bengals", false};
+	{"f18c2_number_X"					, SPECULAR				, "F18C_2_DIF_RoughMet", false};
+	{"f18c2_number_X"					, DECAL					, "empty", true};
+	--USN_MODEX_VERTICAL_STABILIZERS
+	{"f18c2_kil_left"					, DIFFUSE				, "F18C_2_DIFF_VMFA_224_Bengals", false};
+	{"f18c2_kil_left"					, SPECULAR				, "F18C_2_DIF_RoughMet", false};
+	{"f18c2_kil_left"					, DECAL					, "empty", true};
+	{"f18c2_kil_right"					, DIFFUSE				, "F18C_2_DIFF_VMFA_224_Bengals", false};
+	{"f18c2_kil_right"					, SPECULAR				, "F18C_2_DIF_RoughMet", false};
+	{"f18c2_kil_right"					, DECAL					, "empty", true};	
 	
-	--Vertical Stab Aircraft Numbers (USN)
-	--Left
-	{"F18C_BORT_NUMBER_KIL_L_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_L_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_L_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_L_01", DECAL ,"empty",true};	
-	--Right
-	{"F18C_BORT_NUMBER_KIL_R_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_R_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_R_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_R_01", DECAL ,"empty",true};		
-
-	--Nose Aircraft Numbers (KUWAIT)
-	--Left
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_100", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_100", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_01", DECAL ,"empty",true};		
 	
+	--(0.0 = ON, 1.0 OFF)
 
-	--Vertical Stab Numbers (KUWAIT)
-	--Right
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_01", DECAL ,"empty",true};		
+	
+}
 
-	--Nose Aircraft Numbers (FINLAND)
-	--Left
-	{"F18C_BORT_NUMBER_NOSE_fin_L_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_fin_L_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_NOSE_fin_R_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_fin_R_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_01", DECAL ,"empty",true};			
-
-	--Vertical Tail Numbers (SWITZERLAND)
-	--Right
-	{"F18C_BORT_NUMBER_KIL_Switz_R_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Switz_R_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_KIL_Switz_L_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Switz_L_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_01", DECAL ,"empty",true};
-
-	--Gear Door Numbers (RAAF)
-	--Right
-	{"F18C_BORT_NUMBER_STV_aus_R_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_STV_aus_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_STV_aus_R_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_STV_aus_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_STV_aus_L_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_STV_aus_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_STV_aus_L_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_STV_aus_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_L_01", DECAL ,"empty",true};		
-		
-	--Aft Fuselage Numbers (RAAF)
-	--Right
-	{"F18C_BORT_NUMBER_MTW_aus_R_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_MTW_aus_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_MTW_aus_R_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_MTW_aus_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_MTW_aus_L_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_MTW_aus_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_MTW_aus_L_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_MTW_aus_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_L_01", DECAL ,"empty",true};		
+custom_args = {
+	[0027] = 1.0, -- USN_MODEX_VERTICAL_STABILIZERS
+	[1000] = 1.0, -- USN_MODEX_FLAPS
+	[1001] = 1.0, -- USN_MODEX_NOSE
+	[1002] = 1.0, -- KUWAIT_MODEX_NOSE_AND_VERTICAL_STABILIZERS
+	[1003] = 1.0, -- AUSTRAILIA_MODEX_REAR_FUSELAGE_AND_GEAR_DOORS
+	[1004] = 1.0, -- FINLAND_MODEX_FORWARD_FUSELAGE
+	[1005] = 1.0, -- SWITZERLAND_MODEX_VERTICAL_STABILIZERS
 }
 name = "VMFA(AW)-224 Fighting Bengals - 417 - Dangles"
 

--- a/FA-18C_hornet/VMFA-224 - 420 - Redstar/description.lua
+++ b/FA-18C_hornet/VMFA-224 - 420 - Redstar/description.lua
@@ -12,6 +12,30 @@ livery = {
 	{"pilot_F18", 0 ,"../VMFA-224 - 000 - Line/pilot_F18",false};
 	{"pilot_F18", 2 ,"pilot_F18_roughmet",true};
 	
+	--Grey Naval bombs
+	{"GBU_12",	DIFFUSE			,	"gbu_12t_gray_diff", true};
+	{"GBU_12",	NORMAL_MAP			,	"gbu_12_nm", true};
+	{"GBU_12",	ROUGHNESS_METALLIC			,	"gbu_12_diff_roughmet", true};
+	{"MK_82", DIFFUSE, "mk_82t_grey_diff", true};
+	{"MK_82", NORMAL_MAP, "mk_82_nm", true};
+	{"MK_82", ROUGHNESS_METALLIC, "mk_82_diff_roughmet", true};
+	{"mk_83", DIFFUSE, "mk_83tgrey_diff", true};
+	{"mk_83", NORMAL_MAP, "mk_83_nm", true};
+	{"mk_83", ROUGHNESS_METALLIC, "mk_83_diff_roughmet", true};
+	{"GBU_38", DIFFUSE, "gbu_38t_diff", true};
+	{"GBU_38", NORMAL_MAP, "gbu_38_nm", true};
+	{"GBU_38", ROUGHNESS_METALLIC, "gbu_38_diff_roughmet", true};
+	{"GBU_31", DIFFUSE, "gbu_31t_gray_diff", true};
+	{"GBU_31", NORMAL_MAP, "gbu_31_nm", true};
+	{"GBU_31", ROUGHNESS_METALLIC, "gbu_31_diff_roughmet", true};
+	{"mk_84", NORMAL_MAP, "mk_84_nm", true};
+	{"mk_84", ROUGHNESS_METALLIC, "mk_84_diff_roughmet", true};
+	{"GBU_10", DIFFUSE, "gbu_10_diff", true};
+	{"GBU_10", NORMAL_MAP, "gbu_10_nm", true};
+	{"GBU_10", ROUGHNESS_METALLIC, "gbu_10_diff_roughmet", true};
+	{"GBU_16", DIFFUSE, "gbu_16t_gray_diff", true};
+	{"GBU_16", NORMAL_MAP, "gbu_16t_nm", true};
+	{"GBU_16", ROUGHNESS_METALLIC, "gbu_16t_gray_diff_roughmet", true};
 	
 	--Fuel Tanks
 	{"FPU_8A", 0 ,"../VMFA-224 - 000 - Line/FPU_8A1",false};

--- a/FA-18C_hornet/VMFA-224 - 420 - Redstar/description.lua.bak
+++ b/FA-18C_hornet/VMFA-224 - 420 - Redstar/description.lua.bak
@@ -17,186 +17,44 @@ livery = {
 	{"FPU_8A", 0 ,"../VMFA-224 - 000 - Line/FPU_8A1",false};
 	{"FPU_8A", ROUGHNESS_METALLIC ,"FPU_8A_Diff_RoughMet",true};	
 	
-	--Nose Aircraft Numbers (USN)
-	--Left
-	{"F18C_BORT_NUMBER_NOSE_L_100", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_L_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_L_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_L_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_NOSE_R_100", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_R_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_R_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_R_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_R_01", DECAL ,"empty",true};	
-		
-	--Flap Aircraft Numbers (USN)
-	--Left
-	{"F18C_BORT_NUMBER_ZAK_L_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_ZAK_L_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_ZAK_L_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_ZAK_R_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_ZAK_R_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_ZAK_R_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_R_01", DECAL ,"empty",true};
+	--*NEW 2.8.4 Bort Numbers*
+	--USN_MODEX_NOSE
+	{"f18c1_number_nose_left"			, DIFFUSE				, "F18C_1_DIFF_VMFA_224_Bengals", false};
+	{"f18c1_number_nose_left"			, SPECULAR				, "F18C_1_DIF_RoughMet", false};
+	{"f18c1_number_nose_left"			, DECAL					, "empty", true};
+	{"f18c1_number_nose_right"			, DIFFUSE				, "F18C_1_DIFF_VMFA_224_Bengals", false};
+	{"f18c1_number_nose_right"			, SPECULAR				, "F18C_1_DIF_RoughMet", false};
+	{"f18c1_number_nose_right"			, DECAL					, "empty", true};
+	--RAAF /KAF/SWITZ_MODEX_FUSELAGE_FRONT_MID_BACK_GEAR_DOORS_SMALL
+	{"f18c1_number_F"					, DIFFUSE				, "F18C_1_DIFF_VMFA_224_Bengals", false};
+	{"f18c1_number_F"					, SPECULAR				, "F18C_1_DIF_RoughMet", false};
+	{"f18c1_number_F"					, DECAL					, "empty", true};
+	--KAF_MODEX_VERTICAL_STABILIZERS_AND_FLAPS_MODEX
+	{"f18c2_number_X"					, DIFFUSE				, "F18C_2_DIFF_VMFA_224_Bengals", false};
+	{"f18c2_number_X"					, SPECULAR				, "F18C_2_DIF_RoughMet", false};
+	{"f18c2_number_X"					, DECAL					, "empty", true};
+	--USN_MODEX_VERTICAL_STABILIZERS
+	{"f18c2_kil_left"					, DIFFUSE				, "F18C_2_DIFF_VMFA_224_Bengals", false};
+	{"f18c2_kil_left"					, SPECULAR				, "F18C_2_DIF_RoughMet", false};
+	{"f18c2_kil_left"					, DECAL					, "empty", true};
+	{"f18c2_kil_right"					, DIFFUSE				, "F18C_2_DIFF_VMFA_224_Bengals", false};
+	{"f18c2_kil_right"					, SPECULAR				, "F18C_2_DIF_RoughMet", false};
+	{"f18c2_kil_right"					, DECAL					, "empty", true};	
 	
-	--Vertical Stab Aircraft Numbers (USN)
-	--Left
-	{"F18C_BORT_NUMBER_KIL_L_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_L_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_L_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_L_01", DECAL ,"empty",true};	
-	--Right
-	{"F18C_BORT_NUMBER_KIL_R_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_R_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_R_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_R_01", DECAL ,"empty",true};		
-
-	--Nose Aircraft Numbers (KUWAIT)
-	--Left
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_100", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_100", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_01", DECAL ,"empty",true};		
 	
+	--(0.0 = ON, 1.0 OFF)
 
-	--Vertical Stab Numbers (KUWAIT)
-	--Right
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_01", DECAL ,"empty",true};		
+	
+}
 
-	--Nose Aircraft Numbers (FINLAND)
-	--Left
-	{"F18C_BORT_NUMBER_NOSE_fin_L_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_fin_L_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_NOSE_fin_R_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_fin_R_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_01", DECAL ,"empty",true};			
-
-	--Vertical Tail Numbers (SWITZERLAND)
-	--Right
-	{"F18C_BORT_NUMBER_KIL_Switz_R_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Switz_R_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_KIL_Switz_L_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Switz_L_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_01", DECAL ,"empty",true};
-
-	--Gear Door Numbers (RAAF)
-	--Right
-	{"F18C_BORT_NUMBER_STV_aus_R_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_STV_aus_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_STV_aus_R_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_STV_aus_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_STV_aus_L_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_STV_aus_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_STV_aus_L_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_STV_aus_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_L_01", DECAL ,"empty",true};		
-		
-	--Aft Fuselage Numbers (RAAF)
-	--Right
-	{"F18C_BORT_NUMBER_MTW_aus_R_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_MTW_aus_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_MTW_aus_R_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_MTW_aus_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_MTW_aus_L_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_MTW_aus_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_MTW_aus_L_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_MTW_aus_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_L_01", DECAL ,"empty",true};		
+custom_args = {
+	[0027] = 1.0, -- USN_MODEX_VERTICAL_STABILIZERS
+	[1000] = 1.0, -- USN_MODEX_FLAPS
+	[1001] = 1.0, -- USN_MODEX_NOSE
+	[1002] = 1.0, -- KUWAIT_MODEX_NOSE_AND_VERTICAL_STABILIZERS
+	[1003] = 1.0, -- AUSTRAILIA_MODEX_REAR_FUSELAGE_AND_GEAR_DOORS
+	[1004] = 1.0, -- FINLAND_MODEX_FORWARD_FUSELAGE
+	[1005] = 1.0, -- SWITZERLAND_MODEX_VERTICAL_STABILIZERS
 }
 name = "VMFA(AW)-224 Fighting Bengals - 420 - Redstar"
 

--- a/FA-18C_hornet/VMFA-224 - 421 - Epidemik/description.lua
+++ b/FA-18C_hornet/VMFA-224 - 421 - Epidemik/description.lua
@@ -12,6 +12,30 @@ livery = {
 	{"pilot_F18", 0 ,"../VMFA-224 - 000 - Line/pilot_F18",false};
 	{"pilot_F18", 2 ,"pilot_F18_roughmet",true};
 	
+	--Grey Naval bombs
+	{"GBU_12",	DIFFUSE			,	"gbu_12t_gray_diff", true};
+	{"GBU_12",	NORMAL_MAP			,	"gbu_12_nm", true};
+	{"GBU_12",	ROUGHNESS_METALLIC			,	"gbu_12_diff_roughmet", true};
+	{"MK_82", DIFFUSE, "mk_82t_grey_diff", true};
+	{"MK_82", NORMAL_MAP, "mk_82_nm", true};
+	{"MK_82", ROUGHNESS_METALLIC, "mk_82_diff_roughmet", true};
+	{"mk_83", DIFFUSE, "mk_83tgrey_diff", true};
+	{"mk_83", NORMAL_MAP, "mk_83_nm", true};
+	{"mk_83", ROUGHNESS_METALLIC, "mk_83_diff_roughmet", true};
+	{"GBU_38", DIFFUSE, "gbu_38t_diff", true};
+	{"GBU_38", NORMAL_MAP, "gbu_38_nm", true};
+	{"GBU_38", ROUGHNESS_METALLIC, "gbu_38_diff_roughmet", true};
+	{"GBU_31", DIFFUSE, "gbu_31t_gray_diff", true};
+	{"GBU_31", NORMAL_MAP, "gbu_31_nm", true};
+	{"GBU_31", ROUGHNESS_METALLIC, "gbu_31_diff_roughmet", true};
+	{"mk_84", NORMAL_MAP, "mk_84_nm", true};
+	{"mk_84", ROUGHNESS_METALLIC, "mk_84_diff_roughmet", true};
+	{"GBU_10", DIFFUSE, "gbu_10_diff", true};
+	{"GBU_10", NORMAL_MAP, "gbu_10_nm", true};
+	{"GBU_10", ROUGHNESS_METALLIC, "gbu_10_diff_roughmet", true};
+	{"GBU_16", DIFFUSE, "gbu_16t_gray_diff", true};
+	{"GBU_16", NORMAL_MAP, "gbu_16t_nm", true};
+	{"GBU_16", ROUGHNESS_METALLIC, "gbu_16t_gray_diff_roughmet", true};
 	
 	--Fuel Tanks
 	{"FPU_8A", 0 ,"../VMFA-224 - 000 - Line/FPU_8A1",false};

--- a/FA-18C_hornet/VMFA-224 - 421 - Epidemik/description.lua.bak
+++ b/FA-18C_hornet/VMFA-224 - 421 - Epidemik/description.lua.bak
@@ -17,186 +17,44 @@ livery = {
 	{"FPU_8A", 0 ,"../VMFA-224 - 000 - Line/FPU_8A1",false};
 	{"FPU_8A", ROUGHNESS_METALLIC ,"FPU_8A_Diff_RoughMet",true};	
 	
-	--Nose Aircraft Numbers (USN)
-	--Left
-	{"F18C_BORT_NUMBER_NOSE_L_100", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_L_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_L_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_L_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_NOSE_R_100", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_R_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_R_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_R_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_R_01", DECAL ,"empty",true};	
-		
-	--Flap Aircraft Numbers (USN)
-	--Left
-	{"F18C_BORT_NUMBER_ZAK_L_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_ZAK_L_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_ZAK_L_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_ZAK_R_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_ZAK_R_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_ZAK_R_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_R_01", DECAL ,"empty",true};
+	--*NEW 2.8.4 Bort Numbers*
+	--USN_MODEX_NOSE
+	{"f18c1_number_nose_left"			, DIFFUSE				, "F18C_1_DIFF_VMFA_224_Bengals", false};
+	{"f18c1_number_nose_left"			, SPECULAR				, "F18C_1_DIF_RoughMet", false};
+	{"f18c1_number_nose_left"			, DECAL					, "empty", true};
+	{"f18c1_number_nose_right"			, DIFFUSE				, "F18C_1_DIFF_VMFA_224_Bengals", false};
+	{"f18c1_number_nose_right"			, SPECULAR				, "F18C_1_DIF_RoughMet", false};
+	{"f18c1_number_nose_right"			, DECAL					, "empty", true};
+	--RAAF /KAF/SWITZ_MODEX_FUSELAGE_FRONT_MID_BACK_GEAR_DOORS_SMALL
+	{"f18c1_number_F"					, DIFFUSE				, "F18C_1_DIFF_VMFA_224_Bengals", false};
+	{"f18c1_number_F"					, SPECULAR				, "F18C_1_DIF_RoughMet", false};
+	{"f18c1_number_F"					, DECAL					, "empty", true};
+	--KAF_MODEX_VERTICAL_STABILIZERS_AND_FLAPS_MODEX
+	{"f18c2_number_X"					, DIFFUSE				, "F18C_2_DIFF_VMFA_224_Bengals", false};
+	{"f18c2_number_X"					, SPECULAR				, "F18C_2_DIF_RoughMet", false};
+	{"f18c2_number_X"					, DECAL					, "empty", true};
+	--USN_MODEX_VERTICAL_STABILIZERS
+	{"f18c2_kil_left"					, DIFFUSE				, "F18C_2_DIFF_VMFA_224_Bengals", false};
+	{"f18c2_kil_left"					, SPECULAR				, "F18C_2_DIF_RoughMet", false};
+	{"f18c2_kil_left"					, DECAL					, "empty", true};
+	{"f18c2_kil_right"					, DIFFUSE				, "F18C_2_DIFF_VMFA_224_Bengals", false};
+	{"f18c2_kil_right"					, SPECULAR				, "F18C_2_DIF_RoughMet", false};
+	{"f18c2_kil_right"					, DECAL					, "empty", true};	
 	
-	--Vertical Stab Aircraft Numbers (USN)
-	--Left
-	{"F18C_BORT_NUMBER_KIL_L_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_L_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_L_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_L_01", DECAL ,"empty",true};	
-	--Right
-	{"F18C_BORT_NUMBER_KIL_R_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_R_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_R_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_R_01", DECAL ,"empty",true};		
-
-	--Nose Aircraft Numbers (KUWAIT)
-	--Left
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_100", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_100", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_01", DECAL ,"empty",true};		
 	
+	--(0.0 = ON, 1.0 OFF)
 
-	--Vertical Stab Numbers (KUWAIT)
-	--Right
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_01", DECAL ,"empty",true};		
+	
+}
 
-	--Nose Aircraft Numbers (FINLAND)
-	--Left
-	{"F18C_BORT_NUMBER_NOSE_fin_L_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_fin_L_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_NOSE_fin_R_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_fin_R_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_01", DECAL ,"empty",true};			
-
-	--Vertical Tail Numbers (SWITZERLAND)
-	--Right
-	{"F18C_BORT_NUMBER_KIL_Switz_R_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Switz_R_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_KIL_Switz_L_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Switz_L_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_01", DECAL ,"empty",true};
-
-	--Gear Door Numbers (RAAF)
-	--Right
-	{"F18C_BORT_NUMBER_STV_aus_R_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_STV_aus_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_STV_aus_R_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_STV_aus_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_STV_aus_L_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_STV_aus_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_STV_aus_L_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_STV_aus_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_L_01", DECAL ,"empty",true};		
-		
-	--Aft Fuselage Numbers (RAAF)
-	--Right
-	{"F18C_BORT_NUMBER_MTW_aus_R_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_MTW_aus_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_MTW_aus_R_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_MTW_aus_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_MTW_aus_L_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_MTW_aus_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_MTW_aus_L_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_MTW_aus_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_L_01", DECAL ,"empty",true};		
+custom_args = {
+	[0027] = 1.0, -- USN_MODEX_VERTICAL_STABILIZERS
+	[1000] = 1.0, -- USN_MODEX_FLAPS
+	[1001] = 1.0, -- USN_MODEX_NOSE
+	[1002] = 1.0, -- KUWAIT_MODEX_NOSE_AND_VERTICAL_STABILIZERS
+	[1003] = 1.0, -- AUSTRAILIA_MODEX_REAR_FUSELAGE_AND_GEAR_DOORS
+	[1004] = 1.0, -- FINLAND_MODEX_FORWARD_FUSELAGE
+	[1005] = 1.0, -- SWITZERLAND_MODEX_VERTICAL_STABILIZERS
 }
 name = "VMFA(AW)-224 Fighting Bengals - 421 - Epidemik"
 

--- a/FA-18C_hornet/VMFA-224 - 422 - Poon/description.lua
+++ b/FA-18C_hornet/VMFA-224 - 422 - Poon/description.lua
@@ -12,6 +12,30 @@ livery = {
 	{"pilot_F18", 0 ,"../VMFA-224 - 000 - Line/pilot_F18",false};
 	{"pilot_F18", 2 ,"pilot_F18_roughmet",true};
 	
+	--Grey Naval bombs
+	{"GBU_12",	DIFFUSE			,	"gbu_12t_gray_diff", true};
+	{"GBU_12",	NORMAL_MAP			,	"gbu_12_nm", true};
+	{"GBU_12",	ROUGHNESS_METALLIC			,	"gbu_12_diff_roughmet", true};
+	{"MK_82", DIFFUSE, "mk_82t_grey_diff", true};
+	{"MK_82", NORMAL_MAP, "mk_82_nm", true};
+	{"MK_82", ROUGHNESS_METALLIC, "mk_82_diff_roughmet", true};
+	{"mk_83", DIFFUSE, "mk_83tgrey_diff", true};
+	{"mk_83", NORMAL_MAP, "mk_83_nm", true};
+	{"mk_83", ROUGHNESS_METALLIC, "mk_83_diff_roughmet", true};
+	{"GBU_38", DIFFUSE, "gbu_38t_diff", true};
+	{"GBU_38", NORMAL_MAP, "gbu_38_nm", true};
+	{"GBU_38", ROUGHNESS_METALLIC, "gbu_38_diff_roughmet", true};
+	{"GBU_31", DIFFUSE, "gbu_31t_gray_diff", true};
+	{"GBU_31", NORMAL_MAP, "gbu_31_nm", true};
+	{"GBU_31", ROUGHNESS_METALLIC, "gbu_31_diff_roughmet", true};
+	{"mk_84", NORMAL_MAP, "mk_84_nm", true};
+	{"mk_84", ROUGHNESS_METALLIC, "mk_84_diff_roughmet", true};
+	{"GBU_10", DIFFUSE, "gbu_10_diff", true};
+	{"GBU_10", NORMAL_MAP, "gbu_10_nm", true};
+	{"GBU_10", ROUGHNESS_METALLIC, "gbu_10_diff_roughmet", true};
+	{"GBU_16", DIFFUSE, "gbu_16t_gray_diff", true};
+	{"GBU_16", NORMAL_MAP, "gbu_16t_nm", true};
+	{"GBU_16", ROUGHNESS_METALLIC, "gbu_16t_gray_diff_roughmet", true};
 	
 	--Fuel Tanks
 	{"FPU_8A", 0 ,"../VMFA-224 - 000 - Line/FPU_8A1",false};

--- a/FA-18C_hornet/VMFA-224 - 422 - Poon/description.lua.bak
+++ b/FA-18C_hornet/VMFA-224 - 422 - Poon/description.lua.bak
@@ -17,186 +17,44 @@ livery = {
 	{"FPU_8A", 0 ,"../VMFA-224 - 000 - Line/FPU_8A1",false};
 	{"FPU_8A", ROUGHNESS_METALLIC ,"FPU_8A_Diff_RoughMet",true};	
 	
-	--Nose Aircraft Numbers (USN)
-	--Left
-	{"F18C_BORT_NUMBER_NOSE_L_100", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_L_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_L_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_L_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_NOSE_R_100", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_R_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_R_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_R_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_R_01", DECAL ,"empty",true};	
-		
-	--Flap Aircraft Numbers (USN)
-	--Left
-	{"F18C_BORT_NUMBER_ZAK_L_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_ZAK_L_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_ZAK_L_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_ZAK_R_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_ZAK_R_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_ZAK_R_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_R_01", DECAL ,"empty",true};
+	--*NEW 2.8.4 Bort Numbers*
+	--USN_MODEX_NOSE
+	{"f18c1_number_nose_left"			, DIFFUSE				, "F18C_1_DIFF_VMFA_224_Bengals", false};
+	{"f18c1_number_nose_left"			, SPECULAR				, "F18C_1_DIF_RoughMet", false};
+	{"f18c1_number_nose_left"			, DECAL					, "empty", true};
+	{"f18c1_number_nose_right"			, DIFFUSE				, "F18C_1_DIFF_VMFA_224_Bengals", false};
+	{"f18c1_number_nose_right"			, SPECULAR				, "F18C_1_DIF_RoughMet", false};
+	{"f18c1_number_nose_right"			, DECAL					, "empty", true};
+	--RAAF /KAF/SWITZ_MODEX_FUSELAGE_FRONT_MID_BACK_GEAR_DOORS_SMALL
+	{"f18c1_number_F"					, DIFFUSE				, "F18C_1_DIFF_VMFA_224_Bengals", false};
+	{"f18c1_number_F"					, SPECULAR				, "F18C_1_DIF_RoughMet", false};
+	{"f18c1_number_F"					, DECAL					, "empty", true};
+	--KAF_MODEX_VERTICAL_STABILIZERS_AND_FLAPS_MODEX
+	{"f18c2_number_X"					, DIFFUSE				, "F18C_2_DIFF_VMFA_224_Bengals", false};
+	{"f18c2_number_X"					, SPECULAR				, "F18C_2_DIF_RoughMet", false};
+	{"f18c2_number_X"					, DECAL					, "empty", true};
+	--USN_MODEX_VERTICAL_STABILIZERS
+	{"f18c2_kil_left"					, DIFFUSE				, "F18C_2_DIFF_VMFA_224_Bengals", false};
+	{"f18c2_kil_left"					, SPECULAR				, "F18C_2_DIF_RoughMet", false};
+	{"f18c2_kil_left"					, DECAL					, "empty", true};
+	{"f18c2_kil_right"					, DIFFUSE				, "F18C_2_DIFF_VMFA_224_Bengals", false};
+	{"f18c2_kil_right"					, SPECULAR				, "F18C_2_DIF_RoughMet", false};
+	{"f18c2_kil_right"					, DECAL					, "empty", true};	
 	
-	--Vertical Stab Aircraft Numbers (USN)
-	--Left
-	{"F18C_BORT_NUMBER_KIL_L_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_L_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_L_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_L_01", DECAL ,"empty",true};	
-	--Right
-	{"F18C_BORT_NUMBER_KIL_R_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_R_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_R_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_R_01", DECAL ,"empty",true};		
-
-	--Nose Aircraft Numbers (KUWAIT)
-	--Left
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_100", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_100", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_01", DECAL ,"empty",true};		
 	
+	--(0.0 = ON, 1.0 OFF)
 
-	--Vertical Stab Numbers (KUWAIT)
-	--Right
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_01", DECAL ,"empty",true};		
+	
+}
 
-	--Nose Aircraft Numbers (FINLAND)
-	--Left
-	{"F18C_BORT_NUMBER_NOSE_fin_L_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_fin_L_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_NOSE_fin_R_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_fin_R_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_01", DECAL ,"empty",true};			
-
-	--Vertical Tail Numbers (SWITZERLAND)
-	--Right
-	{"F18C_BORT_NUMBER_KIL_Switz_R_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Switz_R_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_KIL_Switz_L_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Switz_L_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_01", DECAL ,"empty",true};
-
-	--Gear Door Numbers (RAAF)
-	--Right
-	{"F18C_BORT_NUMBER_STV_aus_R_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_STV_aus_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_STV_aus_R_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_STV_aus_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_STV_aus_L_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_STV_aus_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_STV_aus_L_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_STV_aus_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_L_01", DECAL ,"empty",true};		
-		
-	--Aft Fuselage Numbers (RAAF)
-	--Right
-	{"F18C_BORT_NUMBER_MTW_aus_R_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_MTW_aus_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_MTW_aus_R_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_MTW_aus_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_MTW_aus_L_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_MTW_aus_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_MTW_aus_L_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_MTW_aus_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_L_01", DECAL ,"empty",true};		
+custom_args = {
+	[0027] = 1.0, -- USN_MODEX_VERTICAL_STABILIZERS
+	[1000] = 1.0, -- USN_MODEX_FLAPS
+	[1001] = 1.0, -- USN_MODEX_NOSE
+	[1002] = 1.0, -- KUWAIT_MODEX_NOSE_AND_VERTICAL_STABILIZERS
+	[1003] = 1.0, -- AUSTRAILIA_MODEX_REAR_FUSELAGE_AND_GEAR_DOORS
+	[1004] = 1.0, -- FINLAND_MODEX_FORWARD_FUSELAGE
+	[1005] = 1.0, -- SWITZERLAND_MODEX_VERTICAL_STABILIZERS
 }
 name = "VMFA(AW)-224 Fighting Bengals - 422 - Poon"
 

--- a/FA-18C_hornet/VMFA-224 - 423 - Blinkers/description.lua
+++ b/FA-18C_hornet/VMFA-224 - 423 - Blinkers/description.lua
@@ -12,6 +12,30 @@ livery = {
 	{"pilot_F18", 0 ,"../VMFA-224 - 000 - Line/pilot_F18",false};
 	{"pilot_F18", 2 ,"pilot_F18_roughmet",true};
 	
+	--Grey Naval bombs
+	{"GBU_12",	DIFFUSE			,	"gbu_12t_gray_diff", true};
+	{"GBU_12",	NORMAL_MAP			,	"gbu_12_nm", true};
+	{"GBU_12",	ROUGHNESS_METALLIC			,	"gbu_12_diff_roughmet", true};
+	{"MK_82", DIFFUSE, "mk_82t_grey_diff", true};
+	{"MK_82", NORMAL_MAP, "mk_82_nm", true};
+	{"MK_82", ROUGHNESS_METALLIC, "mk_82_diff_roughmet", true};
+	{"mk_83", DIFFUSE, "mk_83tgrey_diff", true};
+	{"mk_83", NORMAL_MAP, "mk_83_nm", true};
+	{"mk_83", ROUGHNESS_METALLIC, "mk_83_diff_roughmet", true};
+	{"GBU_38", DIFFUSE, "gbu_38t_diff", true};
+	{"GBU_38", NORMAL_MAP, "gbu_38_nm", true};
+	{"GBU_38", ROUGHNESS_METALLIC, "gbu_38_diff_roughmet", true};
+	{"GBU_31", DIFFUSE, "gbu_31t_gray_diff", true};
+	{"GBU_31", NORMAL_MAP, "gbu_31_nm", true};
+	{"GBU_31", ROUGHNESS_METALLIC, "gbu_31_diff_roughmet", true};
+	{"mk_84", NORMAL_MAP, "mk_84_nm", true};
+	{"mk_84", ROUGHNESS_METALLIC, "mk_84_diff_roughmet", true};
+	{"GBU_10", DIFFUSE, "gbu_10_diff", true};
+	{"GBU_10", NORMAL_MAP, "gbu_10_nm", true};
+	{"GBU_10", ROUGHNESS_METALLIC, "gbu_10_diff_roughmet", true};
+	{"GBU_16", DIFFUSE, "gbu_16t_gray_diff", true};
+	{"GBU_16", NORMAL_MAP, "gbu_16t_nm", true};
+	{"GBU_16", ROUGHNESS_METALLIC, "gbu_16t_gray_diff_roughmet", true};
 	
 	--Fuel Tanks
 	{"FPU_8A", 0 ,"../VMFA-224 - 000 - Line/FPU_8A1",false};

--- a/FA-18C_hornet/VMFA-224 - 423 - Blinkers/description.lua.bak
+++ b/FA-18C_hornet/VMFA-224 - 423 - Blinkers/description.lua.bak
@@ -17,186 +17,44 @@ livery = {
 	{"FPU_8A", 0 ,"../VMFA-224 - 000 - Line/FPU_8A1",false};
 	{"FPU_8A", ROUGHNESS_METALLIC ,"FPU_8A_Diff_RoughMet",true};	
 	
-	--Nose Aircraft Numbers (USN)
-	--Left
-	{"F18C_BORT_NUMBER_NOSE_L_100", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_L_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_L_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_L_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_NOSE_R_100", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_R_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_R_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_R_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_R_01", DECAL ,"empty",true};	
-		
-	--Flap Aircraft Numbers (USN)
-	--Left
-	{"F18C_BORT_NUMBER_ZAK_L_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_ZAK_L_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_ZAK_L_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_ZAK_R_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_ZAK_R_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_ZAK_R_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_ZAK_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_ZAK_R_01", DECAL ,"empty",true};
+	--*NEW 2.8.4 Bort Numbers*
+	--USN_MODEX_NOSE
+	{"f18c1_number_nose_left"			, DIFFUSE				, "F18C_1_DIFF_VMFA_224_Bengals", false};
+	{"f18c1_number_nose_left"			, SPECULAR				, "F18C_1_DIF_RoughMet", false};
+	{"f18c1_number_nose_left"			, DECAL					, "empty", true};
+	{"f18c1_number_nose_right"			, DIFFUSE				, "F18C_1_DIFF_VMFA_224_Bengals", false};
+	{"f18c1_number_nose_right"			, SPECULAR				, "F18C_1_DIF_RoughMet", false};
+	{"f18c1_number_nose_right"			, DECAL					, "empty", true};
+	--RAAF /KAF/SWITZ_MODEX_FUSELAGE_FRONT_MID_BACK_GEAR_DOORS_SMALL
+	{"f18c1_number_F"					, DIFFUSE				, "F18C_1_DIFF_VMFA_224_Bengals", false};
+	{"f18c1_number_F"					, SPECULAR				, "F18C_1_DIF_RoughMet", false};
+	{"f18c1_number_F"					, DECAL					, "empty", true};
+	--KAF_MODEX_VERTICAL_STABILIZERS_AND_FLAPS_MODEX
+	{"f18c2_number_X"					, DIFFUSE				, "F18C_2_DIFF_VMFA_224_Bengals", false};
+	{"f18c2_number_X"					, SPECULAR				, "F18C_2_DIF_RoughMet", false};
+	{"f18c2_number_X"					, DECAL					, "empty", true};
+	--USN_MODEX_VERTICAL_STABILIZERS
+	{"f18c2_kil_left"					, DIFFUSE				, "F18C_2_DIFF_VMFA_224_Bengals", false};
+	{"f18c2_kil_left"					, SPECULAR				, "F18C_2_DIF_RoughMet", false};
+	{"f18c2_kil_left"					, DECAL					, "empty", true};
+	{"f18c2_kil_right"					, DIFFUSE				, "F18C_2_DIFF_VMFA_224_Bengals", false};
+	{"f18c2_kil_right"					, SPECULAR				, "F18C_2_DIF_RoughMet", false};
+	{"f18c2_kil_right"					, DECAL					, "empty", true};	
 	
-	--Vertical Stab Aircraft Numbers (USN)
-	--Left
-	{"F18C_BORT_NUMBER_KIL_L_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_L_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_L_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_L_01", DECAL ,"empty",true};	
-	--Right
-	{"F18C_BORT_NUMBER_KIL_R_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_R_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_R_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_R_01", DECAL ,"empty",true};		
-
-	--Nose Aircraft Numbers (KUWAIT)
-	--Left
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_100", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_100", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_100", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_kuw_R_01", DECAL ,"empty",true};		
 	
+	--(0.0 = ON, 1.0 OFF)
 
-	--Vertical Stab Numbers (KUWAIT)
-	--Right
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Kuw_L_01", DECAL ,"empty",true};		
+	
+}
 
-	--Nose Aircraft Numbers (FINLAND)
-	--Left
-	{"F18C_BORT_NUMBER_NOSE_fin_L_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_fin_L_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_L_01", DECAL ,"empty",true};
-	--Right
-	{"F18C_BORT_NUMBER_NOSE_fin_R_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_NOSE_fin_R_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_NOSE_fin_R_01", DECAL ,"empty",true};			
-
-	--Vertical Tail Numbers (SWITZERLAND)
-	--Right
-	{"F18C_BORT_NUMBER_KIL_Switz_R_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Switz_R_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_KIL_Switz_L_100", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_100", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_100", DECAL ,"empty",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_10", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_10", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_KIL_Switz_L_01", 0 ,"F18C_2_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_01", ROUGHNESS_METALLIC ,"F18C_2_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_KIL_Switz_L_01", DECAL ,"empty",true};
-
-	--Gear Door Numbers (RAAF)
-	--Right
-	{"F18C_BORT_NUMBER_STV_aus_R_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_STV_aus_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_STV_aus_R_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_STV_aus_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_STV_aus_L_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_STV_aus_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_STV_aus_L_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_STV_aus_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_STV_aus_L_01", DECAL ,"empty",true};		
-		
-	--Aft Fuselage Numbers (RAAF)
-	--Right
-	{"F18C_BORT_NUMBER_MTW_aus_R_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_MTW_aus_R_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_R_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_MTW_aus_R_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_MTW_aus_R_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_R_01", DECAL ,"empty",true};	
-	--Left
-	{"F18C_BORT_NUMBER_MTW_aus_L_10", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_MTW_aus_L_10", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_L_10", DECAL ,"empty",true};	
-	{"F18C_BORT_NUMBER_MTW_aus_L_01", 0 ,"F18C_1_DIFF_VMFA_224_Bengals",false};
-	{"F18C_BORT_NUMBER_MTW_aus_L_01", ROUGHNESS_METALLIC ,"F18C_1_DIF_RoughMet",true};
-	{"F18C_BORT_NUMBER_MTW_aus_L_01", DECAL ,"empty",true};		
+custom_args = {
+	[0027] = 1.0, -- USN_MODEX_VERTICAL_STABILIZERS
+	[1000] = 1.0, -- USN_MODEX_FLAPS
+	[1001] = 1.0, -- USN_MODEX_NOSE
+	[1002] = 1.0, -- KUWAIT_MODEX_NOSE_AND_VERTICAL_STABILIZERS
+	[1003] = 1.0, -- AUSTRAILIA_MODEX_REAR_FUSELAGE_AND_GEAR_DOORS
+	[1004] = 1.0, -- FINLAND_MODEX_FORWARD_FUSELAGE
+	[1005] = 1.0, -- SWITZERLAND_MODEX_VERTICAL_STABILIZERS
 }
 name = "VMFA(AW)-224 Fighting Bengals - 423 - Blinkers"
 


### PR DESCRIPTION
GBU-12, Mk82, mk83, GBU-38, GBU-31, GBU-16 changed to navalized post-2002 grey versions